### PR TITLE
add channel property to message

### DIFF
--- a/src/Bunny/Channel.php
+++ b/src/Bunny/Channel.php
@@ -400,7 +400,8 @@ class Channel
                 $response->exchange,
                 $response->routingKey,
                 $this->headerFrame->toArray(),
-                $this->bodyBuffer->consume($this->bodyBuffer->getLength())
+                $this->bodyBuffer->consume($this->bodyBuffer->getLength()),
+                $this
             );
 
             $this->headerFrame = null;
@@ -697,7 +698,8 @@ class Channel
                 $this->returnFrame->exchange,
                 $this->returnFrame->routingKey,
                 $this->headerFrame->toArray(),
-                $content
+                $content,
+                $this
             );
 
             foreach ($this->returnCallbacks as $callback) {
@@ -717,7 +719,8 @@ class Channel
                     $this->deliverFrame->exchange,
                     $this->deliverFrame->routingKey,
                     $this->headerFrame->toArray(),
-                    $content
+                    $content,
+                    $this
                 );
 
                 $callback = $this->deliverCallbacks[$this->deliverFrame->consumerTag];
@@ -741,7 +744,8 @@ class Channel
                 $this->getOkFrame->exchange,
                 $this->getOkFrame->routingKey,
                 $this->headerFrame->toArray(),
-                $content
+                $content,
+                $this
             ));
 
             $this->getOkFrame = null;

--- a/src/Bunny/Message.php
+++ b/src/Bunny/Message.php
@@ -43,6 +43,7 @@ class Message
      * @param string $routingKey
      * @param array $headers
      * @param string $content
+     * @param \Bunny\Channel $channel
      */
     public function __construct($consumerTag, $deliveryTag, $redelivered, $exchange, $routingKey, array $headers, $content, $channel)
     {

--- a/src/Bunny/Message.php
+++ b/src/Bunny/Message.php
@@ -29,6 +29,9 @@ class Message
 
     /** @var string */
     public $content;
+    
+    /** @var \Bunny\Channel */
+    public $channel;
 
     /**
      * Constructor.

--- a/src/Bunny/Message.php
+++ b/src/Bunny/Message.php
@@ -44,7 +44,7 @@ class Message
      * @param array $headers
      * @param string $content
      */
-    public function __construct($consumerTag, $deliveryTag, $redelivered, $exchange, $routingKey, array $headers, $content)
+    public function __construct($consumerTag, $deliveryTag, $redelivered, $exchange, $routingKey, array $headers, $content, $channel)
     {
         $this->consumerTag = $consumerTag;
         $this->deliveryTag = $deliveryTag;
@@ -53,6 +53,7 @@ class Message
         $this->routingKey = $routingKey;
         $this->headers = $headers;
         $this->content = $content;
+        $this->channel = $channel;
     }
 
     /**


### PR DESCRIPTION
When working with multiple channels it's a bit ugly to keep in mind which channel received message. This patch allows to use more simple code.