### PR TITLE
allow for parse_url result to be used as options

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -92,6 +92,9 @@ abstract class AbstractClient
             if (isset($options["virtual_host"])) {
                 $options["vhost"] = $options["virtual_host"];
                 unset($options["virtual_host"]);
+            } elseif (isset($options["path"])) {
+                $options["vhost"] = $options["path"];
+                unset($options["path"]);
             } else {
                 $options["vhost"] = "/";
             }


### PR DESCRIPTION
This change allows to use it with parse_url, since the vhost is set as path argument in the result:

```
$url = amqp://user:password@host:port/vhost
$options = parse_url($url);
$client = new Client($options);
```