### PR TITLE
Use done() instead of then() when not returning a promise

### DIFF
--- a/spec/generate.php
+++ b/spec/generate.php
@@ -335,12 +335,12 @@ $clientMethodsContent .= "                if (\$frame instanceof Protocol\\Conte
 $clientMethodsContent .= "                    \$deferred->resolve(\$frame);\n";
 $clientMethodsContent .= "                    return true;\n";
 $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodChannelCloseFrame && \$frame->channel === \$channel) {\n";
-$clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->then(function () use (\$frame, \$deferred) {\n";
+$clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->done(function () use (\$frame, \$deferred) {\n";
 $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
 $clientMethodsContent .= "                    });\n";
 $clientMethodsContent .= "                    return true;\n";
 $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodConnectionCloseFrame) {\n";
-$clientMethodsContent .= "                    \$this->connectionCloseOk()->then(function () use (\$frame, \$deferred) {\n";
+$clientMethodsContent .= "                    \$this->connectionCloseOk()->done(function () use (\$frame, \$deferred) {\n";
 $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
 $clientMethodsContent .= "                    });\n";
 $clientMethodsContent .= "                    return true;\n";
@@ -382,12 +382,12 @@ $clientMethodsContent .= "                if (\$frame instanceof Protocol\\Conte
 $clientMethodsContent .= "                    \$deferred->resolve(\$frame);\n";
 $clientMethodsContent .= "                    return true;\n";
 $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodChannelCloseFrame && \$frame->channel === \$channel) {\n";
-$clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->then(function () use (\$frame, \$deferred) {\n";
+$clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->done(function () use (\$frame, \$deferred) {\n";
 $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
 $clientMethodsContent .= "                    });\n";
 $clientMethodsContent .= "                    return true;\n";
 $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodConnectionCloseFrame) {\n";
-$clientMethodsContent .= "                    \$this->connectionCloseOk()->then(function () use (\$frame, \$deferred) {\n";
+$clientMethodsContent .= "                    \$this->connectionCloseOk()->done(function () use (\$frame, \$deferred) {\n";
 $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
 $clientMethodsContent .= "                    });\n";
 $clientMethodsContent .= "                    return true;\n";
@@ -853,13 +853,13 @@ foreach ($spec->classes as $class) {
             }
             if ($class->id !== 10) {
                 $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodChannelCloseFrame && \$frame->channel === \$channel) {\n";
-                $clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->then(function () use (\$frame, \$deferred) {\n";
+                $clientMethodsContent .= "                    \$this->channelCloseOk(\$channel)->done(function () use (\$frame, \$deferred) {\n";
                 $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
                 $clientMethodsContent .= "                    });\n";
                 $clientMethodsContent .= "                    return true;\n";
             }
             $clientMethodsContent .= "                } elseif (\$frame instanceof Protocol\\MethodConnectionCloseFrame) {\n";
-            $clientMethodsContent .= "                    \$this->connectionCloseOk()->then(function () use (\$frame, \$deferred) {\n";
+            $clientMethodsContent .= "                    \$this->connectionCloseOk()->done(function () use (\$frame, \$deferred) {\n";
             $clientMethodsContent .= "                        \$deferred->reject(new ClientException(\$frame->replyText, \$frame->replyCode));\n";
             $clientMethodsContent .= "                    });\n";
             $clientMethodsContent .= "                    return true;\n";

--- a/src/Bunny/Async/Client.php
+++ b/src/Bunny/Async/Client.php
@@ -324,7 +324,7 @@ class Client extends AbstractClient
 
         if ($now >= $nextHeartbeat) {
             $this->writer->appendFrame(new HeartbeatFrame(), $this->writeBuffer);
-            $this->flushWriteBuffer()->then(function () {
+            $this->flushWriteBuffer()->done(function () {
                 $this->heartbeatTimer = $this->eventLoop->addTimer($this->options["heartbeat"], [$this, "onHeartbeat"]);
             });
 

--- a/src/Bunny/Channel.php
+++ b/src/Bunny/Channel.php
@@ -280,7 +280,7 @@ class Channel
             $this->client->run();
 
         } elseif ($response instanceof PromiseInterface) {
-            $response->then(function () {
+            $response->done(function () {
                 $this->client->run();
             });
 
@@ -348,7 +348,7 @@ class Channel
         if ($response instanceof PromiseInterface) {
             $this->getDeferred = new Deferred();
 
-            $response->then(function ($frame) {
+            $response->done(function ($frame) {
                 if ($frame instanceof MethodBasicGetEmptyFrame) {
                     // deferred has to be first nullified and then resolved, otherwise results in race condition
                     $deferred = $this->getDeferred;

--- a/src/Bunny/Client.php
+++ b/src/Bunny/Client.php
@@ -53,7 +53,7 @@ class Client extends AbstractClient
     public function __destruct()
     {
         if ($this->isConnected()) {
-            $this->disconnect()->then(function () {
+            $this->disconnect()->done(function () {
                 $this->stop();
             });
 

--- a/src/Bunny/ClientMethods.php
+++ b/src/Bunny/ClientMethods.php
@@ -88,12 +88,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -136,12 +136,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -182,7 +182,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -237,7 +237,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -288,7 +288,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -357,7 +357,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -412,7 +412,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -462,7 +462,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -500,7 +500,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -538,7 +538,7 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -592,12 +592,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -654,12 +654,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -715,12 +715,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -779,12 +779,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -839,12 +839,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -902,12 +902,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -973,12 +973,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1041,12 +1041,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1113,12 +1113,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1185,12 +1185,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1255,12 +1255,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1327,12 +1327,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1395,12 +1395,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1463,12 +1463,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1530,12 +1530,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1594,12 +1594,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1665,12 +1665,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1732,12 +1732,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -1965,12 +1965,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2013,12 +2013,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2080,12 +2080,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2144,12 +2144,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2233,12 +2233,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2295,12 +2295,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2356,12 +2356,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2417,12 +2417,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2478,12 +2478,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
@@ -2544,12 +2544,12 @@ trait ClientMethods
                     $deferred->resolve($frame);
                     return true;
                 } elseif ($frame instanceof Protocol\MethodChannelCloseFrame && $frame->channel === $channel) {
-                    $this->channelCloseOk($channel)->then(function () use ($frame, $deferred) {
+                    $this->channelCloseOk($channel)->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
                 } elseif ($frame instanceof Protocol\MethodConnectionCloseFrame) {
-                    $this->connectionCloseOk()->then(function () use ($frame, $deferred) {
+                    $this->connectionCloseOk()->done(function () use ($frame, $deferred) {
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;

--- a/test/Bunny/AsyncClientTest.php
+++ b/test/Bunny/AsyncClientTest.php
@@ -23,7 +23,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
             return $client->disconnect();
         })->then(function () use ($loop) {
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -45,7 +45,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
             return $client->disconnect();
         })->then(function () use ($loop) {
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -68,9 +68,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
         $client->connect()->then(function () use ($loop) {
             $this->fail("client should not connect");
             $loop->stop();
-        }, function ($e) use ($loop) {
-            throw $e;
-        });
+        })->done();
 
         $loop->run();
     }
@@ -90,7 +88,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
             return $ch->getClient()->disconnect();
         })->then(function () use ($loop) {
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -124,7 +122,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
 
         })->then(function () use ($loop) {
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -151,7 +149,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
         }, function (\Exception $e) use ($loop) {
             $this->assertInstanceOf("Bunny\\Exception\\ClientException", $e);
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -178,7 +176,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
 
                     ++$processed;
 
-                    $client->disconnect()->then(function () use ($loop) {
+                    $client->disconnect()->done(function () use ($loop) {
                         $loop->stop();
                     });
 
@@ -187,7 +185,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
                 $channel->publish(".", [], "", "disconnect_test"),
                 $channel->publish(".", [], "", "disconnect_test"),
             ]);
-        });
+        })->done();
 
         $loop->run();
 
@@ -248,7 +246,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
 
         })->then(function () use ($loop) {
             $loop->stop();
-        });
+        })->done();
 
         $loop->run();
     }
@@ -283,7 +281,7 @@ class AsyncClientTest extends \PHPUnit_Framework_TestCase
             });
 
             return $channel->publish("xxx", [], "", "404", true);
-        });
+        })->done();
 
         $loop->run();
 

--- a/test/Bunny/ChannelTest.php
+++ b/test/Bunny/ChannelTest.php
@@ -10,7 +10,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
         $c->connect();
         $promise = $c->channel()->close();
         $this->assertInstanceOf("React\\Promise\\PromiseInterface", $promise);
-        $promise->then(function () use ($c) {
+        $promise->done(function () use ($c) {
             $c->stop();
         });
         $c->run();

--- a/test/Bunny/ClientTest.php
+++ b/test/Bunny/ClientTest.php
@@ -81,7 +81,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $channel->consume(function (Message $message, Channel $channel) use ($client, &$processed) {
             $channel->ack($message);
             ++$processed;
-            $client->disconnect()->then(function () use ($client) {
+            $client->disconnect()->done(function () use ($client) {
                 $client->stop();
             });
         });
@@ -131,7 +131,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         })->then(function () use ($client) {
             $client->stop();
-        });
+        })->done();
 
         $client->run(5);
     }
@@ -237,7 +237,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->assertEmpty($message->content);
             $channel->ack($message);
             if (++$processed === 2) {
-                $client->disconnect()->then(function () use ($client) {
+                $client->disconnect()->done(function () use ($client) {
                     $client->stop();
                 });
             }


### PR DESCRIPTION
When only consuming a promise, done() should be used instead of then().
This has the following advantages:

* Unhandled rejections are rethrown as exceptions and will not get swallowed
* No unused child promises are created which saves some memory

See: https://github.com/reactphp/promise/tree/v2.2.0#done-vs-then