### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/log": "~1.0",
-        "react/event-loop": "~0.4",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4",
         "react/promise": "~2.2"
     },
     "require-dev": {

--- a/src/Bunny/Async/Client.php
+++ b/src/Bunny/Async/Client.php
@@ -123,7 +123,7 @@ class Client extends AbstractClient
     public function stop()
     {
         if ($this->stopTimer) {
-            $this->stopTimer->cancel();
+            $this->eventLoop->cancelTimer($this->stopTimer);
             $this->stopTimer = null;
         }
 
@@ -256,7 +256,7 @@ class Client extends AbstractClient
         }
 
         if ($this->heartbeatTimer) {
-            $this->heartbeatTimer->cancel();
+            $this->eventLoop->cancelTimer($this->heartbeatTimer);
             $this->heartbeatTimer = null;
         }
 


### PR DESCRIPTION
We've just released `react/event-loop` [0.5](https://github.com/reactphp/event-loop/releases/tag/v0.5.0) which will be our last BC breaking release before 1.0. And aside from two changes `bunny/bunny` is fully compatible :tada: .