### PR TITLE
Fixed Issue #62: Modified unset() statement which lead to exceptions.

### DIFF
--- a/src/Bunny/Channel.php
+++ b/src/Bunny/Channel.php
@@ -587,7 +587,7 @@ class Channel
                 }
 
                 // break reference cycle, must be called after resolving promise
-                unset($this->client);
+                $this->client = null;
                 // break consumers' reference cycle
                 $this->deliverCallbacks = [];
 


### PR DESCRIPTION
Unsetting properties on non-dynamic classes causes all sorts of potential problems.