### PR TITLE
Add the sendHeartbeat method to the AbstractClient class

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -489,4 +489,13 @@ abstract class AbstractClient
         throw new ClientException("No available channels");
     }
 
+    /**
+     * @return void
+     */
+    public function sendHeartbeat()
+    {
+        $this->getWriter()->appendFrame(new HeartbeatFrame(), $this->getWriteBuffer());
+        $this->flushWriteBuffer();
+    }
+
 }


### PR DESCRIPTION
In a long running consumer I need to send the heartbeat frames periodically to prevent the client disconnection.