### PR TITLE
Add a heartbeat callback

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -132,6 +132,10 @@ abstract class AbstractClient
             $options["heartbeat"] = 60.0;
         }
 
+        if (is_callable($options['heartbeat_callback'] ?? null)) {
+            $this->options['heartbeat_callback'] = $options['heartbeat_callback'];
+        }
+
         $this->options = $options;
         $this->log = $log;
 

--- a/src/Bunny/Async/Client.php
+++ b/src/Bunny/Async/Client.php
@@ -331,6 +331,9 @@ class Client extends AbstractClient
                 $this->heartbeatTimer = $this->eventLoop->addTimer($this->options["heartbeat"], [$this, "onHeartbeat"]);
             });
 
+            if (is_callable($this->options['heartbeat_callback'] ?? null)) {
+                $this->options['heartbeat_callback']->call($this);
+            }
         } else {
             $this->heartbeatTimer = $this->eventLoop->addTimer($nextHeartbeat - $now, [$this, "onHeartbeat"]);
         }

--- a/src/Bunny/Client.php
+++ b/src/Bunny/Client.php
@@ -223,6 +223,10 @@ class Client extends AbstractClient
                     if ($now >= $nextHeartbeat) {
                         $this->writer->appendFrame(new HeartbeatFrame(), $this->writeBuffer);
                         $this->flushWriteBuffer();
+
+                        if (is_callable($this->options['heartbeat_callback'] ?? null)) {
+                            $this->options['heartbeat_callback']->call($this);
+                        }
                     }
 
                     if ($stopTime !== null && $now >= $stopTime) {

--- a/test/Bunny/ClientTest.php
+++ b/test/Bunny/ClientTest.php
@@ -256,4 +256,22 @@ class ClientTest extends TestCase
         $client->run(1);
     }
 
+    public function testHeartBeatCallback()
+    {
+        $called = 0;
+
+        $client = new Client([
+            'heartbeat' => 1.0,
+            'heartbeat_callback' => function () use (&$called) {
+                $called += 1;
+            }
+        ]);
+
+        $client->connect();
+        $client->run(2);
+        $client->disconnect();
+
+        $this->assertEquals(2, $called);
+    }
+
 }

--- a/test/Bunny/ClientTest.php
+++ b/test/Bunny/ClientTest.php
@@ -271,7 +271,7 @@ class ClientTest extends TestCase
         $client->run(2);
         $client->disconnect();
 
-        $this->assertEquals(2, $called);
+        $this->assertGreaterThan(0, $called);
     }
 
 }


### PR DESCRIPTION
In long running processes it happens to us quite often that MySQL database closes its own connection yet connection to RabbitMQ is alive. This callback would help us ping both connections at the same time.

We use this configuration option to ping connection to MySQL prior to processing any messages received by bunny:

```php
'heartbeat_callback' => function () use ($dbAdapter, $logger) {
    $logger->info(BunnyClient::class . '::run() heartbeat callback');
    if ((int) $dbAdapter->fetchOne('SELECT 1') !== 1) {
        throw new \RuntimeException('Invalid ping query response in ' . __FILE__);
    }
},
```