### PR TITLE
Add description when channel.close is received

### DIFF
--- a/src/Bunny/Channel.php
+++ b/src/Bunny/Channel.php
@@ -14,6 +14,7 @@ use Bunny\Protocol\MethodBasicGetEmptyFrame;
 use Bunny\Protocol\MethodBasicGetOkFrame;
 use Bunny\Protocol\MethodBasicNackFrame;
 use Bunny\Protocol\MethodBasicReturnFrame;
+use Bunny\Protocol\MethodChannelCloseFrame;
 use Bunny\Protocol\MethodChannelCloseOkFrame;
 use Bunny\Protocol\MethodFrame;
 use React\Promise\Deferred;
@@ -618,6 +619,8 @@ class Channel
                 foreach ($this->ackCallbacks as $callback) {
                     $callback($frame);
                 }
+            } elseif ($frame instanceof MethodChannelCloseFrame) {
+                throw new ChannelException("Channel closed by server: " . $frame->replyText, $frame->replyCode);
 
             } else {
                 throw new ChannelException("Unhandled method frame " . get_class($frame) . ".");


### PR DESCRIPTION
After some refactoring my eventloop started throwing this error:

```
  [Bunny\Exception\ChannelException]                              
  Unhandled method frame Bunny\Protocol\MethodChannelCloseFrame.  
```

After some googling I found this commit which seems to solve a similar issue: https://github.com/jakubkulhan/bunny/commit/ed7018d7ac98af42e0a1412748d6f64328817179

So I tried to use the same idea to add more error description here. With my change the error changed:

```
  [Bunny\Exception\ChannelException (406)]                                   
  Connection closed by server: PRECONDITION_FAILED - unknown delivery tag 1  
```

Of course I don't really know what this error is either yet, but at least it's more specific than the old one and should lead me somewhere - I hope.