### PR TITLE
Use tcp_delay on PHP > 7.1.0 to speed up connection

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -228,8 +228,19 @@ abstract class AbstractClient
 
                 $uri .= (strpos($this->options["path"], "/") === 0) ? $this->options["path"] : "/" . $this->options["path"];
             }
-
-            $this->stream = @stream_socket_client($uri, $errno, $errstr, (float)$this->options["timeout"], $flags);
+            
+            // tcp_nodelay was added in 7.1.0
+            if (PHP_VERSION_ID >= 70100) {
+                $context = stream_context_create([
+                    "socket" => [
+                        "tcp_nodelay" => true
+                    ]
+                ]);
+            } else {
+                $context = stream_context_create();
+            }
+            
+            $this->stream = @stream_socket_client($uri, $errno, $errstr, (float)$this->options["timeout"], $flags, $context);
 
             if (!$this->stream) {
                 throw new ClientException(


### PR DESCRIPTION
Create stream_context with `tcp_delay` on PHP > 7.1.0 to speed up connection.  In my case on localhost from 50ms to 5ms.
Related to [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib) issues 
- [#516 Connect to Rabbitmq may cost too many time](https://github.com/php-amqplib/php-amqplib/issues/516)
- [#449 Benchmarking: stream vs socket vs extension](https://github.com/php-amqplib/php-amqplib/issues/449)

fixed by [Use tcp_nodelay for StreamIO](https://github.com/php-amqplib/php-amqplib/pull/517/commits/40cee49875c920237e4ccdf2b40d89dc4a364e96)
