### PR TITLE
Typehint to DateTimeInterface to allow DateTimeImmutable values

### DIFF
--- a/src/Bunny/Protocol/ProtocolWriter.php
+++ b/src/Bunny/Protocol/ProtocolWriter.php
@@ -172,10 +172,10 @@ class ProtocolWriter
     /**
      * Appends AMQP timestamp to buffer.
      *
-     * @param \DateTime $value
+     * @param \DateTimeInterface $value
      * @param Buffer $buffer
      */
-    public function appendTimestamp(\DateTime $value, Buffer $buffer)
+    public function appendTimestamp(\DateTimeInterface $value, Buffer $buffer)
     {
         $buffer->appendUint64($value->getTimestamp());
     }
@@ -233,7 +233,7 @@ class ProtocolWriter
         } elseif (is_null($value)) {
             $buffer->appendUint8(Constants::FIELD_NULL);
 
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $buffer->appendUint8(Constants::FIELD_TIMESTAMP);
             $this->appendTimestamp($value, $buffer);
 

--- a/test/Bunny/Protocol/ProtocolWriterTest.php
+++ b/test/Bunny/Protocol/ProtocolWriterTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace Bunny\Protocol;
+
+use Bunny\Constants;
+use DateTime;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class ProtocolWriterTest extends TestCase
+{
+    public function test_appendFieldValue_canHandleDateTime()
+    {
+        $buffer = $this->createMock(Buffer::class);
+        $protocolWriter = new ProtocolWriter();
+
+        $date = new DateTime();
+
+        $buffer->expects($this->once())
+            ->method('appendUint8')
+            ->with(Constants::FIELD_TIMESTAMP);
+        $buffer->expects($this->once())
+            ->method('appendUint64')
+            ->with($date->getTimestamp());
+
+        $protocolWriter->appendFieldValue($date, $buffer);
+    }
+
+    public function test_appendFieldValue_canHandleDateTimeImmutable()
+    {
+        $buffer = $this->createMock(Buffer::class);
+        $protocolWriter = new ProtocolWriter();
+
+        $date = new DateTimeImmutable();
+
+        $buffer->expects($this->once())
+            ->method('appendUint8')
+            ->with(Constants::FIELD_TIMESTAMP);
+        $buffer->expects($this->once())
+            ->method('appendUint64')
+            ->with($date->getTimestamp());
+
+        $protocolWriter->appendFieldValue($date, $buffer);
+    }
+}


### PR DESCRIPTION
This is for the PHP->AMQP type conversion only. Most of our code uses DateTimeImmutable types ( as our dates are not mutable :)). This safes us from having to cast them. 
From what I understood this part is not auto-generated. This should also be no BC break. 