### PR TITLE
Throw exception on too high heartbeat value

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -131,8 +131,8 @@ abstract class AbstractClient
 
         if (!isset($options["heartbeat"])) {
             $options["heartbeat"] = 60.0;
-        } elseif ($options['heartbeat'] >= 2**16) {
-            throw new InvalidArgumentException('Heartbeat too high: the value is int16.');
+        } elseif ($options["heartbeat"] >= 2**15) {
+            throw new InvalidArgumentException("Heartbeat too high: the value is a signed int16.");
         }
 
         if (is_callable($options['heartbeat_callback'] ?? null)) {

--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -13,6 +13,7 @@ use Bunny\Protocol\MethodConnectionStartFrame;
 use Bunny\Protocol\MethodFrame;
 use Bunny\Protocol\ProtocolReader;
 use Bunny\Protocol\ProtocolWriter;
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use React\Promise;
 
@@ -130,6 +131,8 @@ abstract class AbstractClient
 
         if (!isset($options["heartbeat"])) {
             $options["heartbeat"] = 60.0;
+        } elseif ($options['heartbeat'] >= 2**16) {
+            throw new InvalidArgumentException('Heartbeat too high: the value is int16.');
         }
 
         if (is_callable($options['heartbeat_callback'] ?? null)) {


### PR DESCRIPTION
When setting the heartbeat value to 1 day (86400), the connections were dropped by RabbitMQ server with the error:

```
2020-09-25 09:47:25.801 [error] <0.29687.6432> closing AMQP connection <0.29687.6432> (:38384 -> :5672):
missed heartbeats from client, timeout: 20864s
```

```
86400 % (2**15)
20864
```

This has lead us to discrepancy between [int16 value sent to RabbitMQ server](https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/ClientMethods.php#L327) and [the value the client checks](https://github.com/jakubkulhan/bunny/blob/d27e81699408ef02d959bf64c75e8dcaacbd0639/src/Bunny/Client.php#L192) (which is still the generic php int/float).

This should be pointed out when constructing the client instance.