### PR TITLE
Fix swallowing exceptions

### DIFF
--- a/src/Bunny/Async/Client.php
+++ b/src/Bunny/Async/Client.php
@@ -161,13 +161,17 @@ class Client extends AbstractClient
                     if ($this->writeBuffer->isEmpty()) {
                         $this->eventLoop->removeWriteStream($stream);
                         $this->flushWriteBufferPromise = null;
-                        $deferred->resolve(true);
+                        $this->eventLoop->futureTick(function () use ($deferred) {
+                            $deferred->resolve(true);
+                        });
                     }
 
                 } catch (\Exception $e) {
                     $this->eventLoop->removeWriteStream($stream);
                     $this->flushWriteBufferPromise = null;
-                    $deferred->reject($e);
+                    $this->eventLoop->futureTick(function () use ($deferred, $e) {
+                        $deferred->reject($e);
+                    });
                 }
             });
 


### PR DESCRIPTION
First of all, I'm doing my first steps using ReactPHP, trying to use the async client. Therefore my understanding and assumptions may be wrong.

Of course, I did something wrong during my tests (tried to consume a non-existing queue) but didn't get an exception. During my research I found #39 and #36 and I thought I would try to find a solution.

From my understanding (which might be wrong), the problematic line (at least for my problem) is [here](https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/ClientMethods.php#L1259).
The callback passed to `done` gets executed in the happy path and immediately rejects the deferred value.
Now, the rejection causes several callbacks of the promise chain to be executed which will finally throw the exception if it is unhandled.
The thrown exception gets caught [here](https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/Async/Client.php#L167) which rejects the deferred value with the caught exception but this somehow swallows the exception.
I think this happens because there are several calls of `ClientMethods::flushWriteBuffer` in different places where the possibly returned Promise is just ignored, e.g. [here](https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/ClientMethods.php#L1239).

According to the docs, the callback passed to `LoopInterface::addWriteStream` is not allowed to throw an exception, so (re)throwing the exception [here](https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/Async/Client.php#L167) is no option.

Instead, I tried to defer resolving/rejecting the deferred value from within the callback to a future tick of the event loop. This way, the callback still does not throw, fulfilling the requirements, and (re)throwing the exception eventually happens within the event loop where it seems to be handled correctly.

I tried to write tests for this behaviour using the example code from #36.

I think it shouldn't cause any issues since resolving/rejecting the deferred value is just delayed a little bit until the next tick of the event loop.