### PR TITLE
Added catch to __destruct to prevent fatal error

### DIFF
--- a/src/Bunny/Client.php
+++ b/src/Bunny/Client.php
@@ -53,16 +53,20 @@ class Client extends AbstractClient
      */
     public function __destruct()
     {
+        try {
         if ($this->isConnected()) {
-            $this->disconnect()->done(function () {
-                $this->stop();
-            });
+                $this->disconnect()->done(function () {
+                    $this->stop();
+                });
 
-            // has to re-check if connected, because disconnect() can set connection state immediately
-            if ($this->isConnected()) {
-                $this->run();
+                // has to re-check if connected, because disconnect() can set connection state immediately
+                if ($this->isConnected()) {
+                    $this->run();
+                }
             }
-        }
+        } catch (\Throwable $e) {
+            // silently ignore - we dont want any exceptions to be thrown in __destruct as that will trigger fatal error
+        } 
     }
 
     /**


### PR DESCRIPTION
Hello

please check the changes I made. I know it's far from being optimal as that will catch any logical error, not just client exception etc but the fatal error in the __destruct was quite hard to find - the application was returning all data in the request yet the HTTP status was 500. 

I recently migrated to https://github.com/cloudamqp/amqproxy since php cannot keep the connection opened. After the migration around 30% of requests started to fail with https://github.com/jakubkulhan/bunny/blob/master/src/Bunny/AbstractClient.php#L311

Apart from my solution what would you suggest is the best way to treat exceptions in destructor?