### PR TITLE
Add support for setting client properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ Note: invalid SSL configuration will cause connection failure.
 
 See also [common configuration variants](examples/ssl/).
 
+### Providing client properties
+
+Client Connections can [present their capabilities](https://www.rabbitmq.com/connections.html#capabilities) to
+a server by presenting an optional `client_properties` table when establishing a connection.
+
+For example, a connection name may be provided by setting the
+[`connection_name` property](https://www.rabbitmq.com/connections.html#client-provided-names):
+
+```php
+$connection = [
+    'host'              => 'HOSTNAME',
+    'vhost'             => 'VHOST',    // The default vhost is /
+    'user'              => 'USERNAME', // The default user is guest
+    'password'          => 'PASSWORD', // The default password is guest
+    'client_properties' => [
+        'connection_name' => 'My connection',
+    ],
+];
+
+$bunny = new Client($connection);
+$bunny->connect();
+```
+
 ### Publish a message
 
 Now that we have a connection with the server we need to create a channel and declare a queue to communicate over before we can publish a message, or subscribe to a queue for that matter.

--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -138,6 +138,14 @@ abstract class AbstractClient
             $this->options['heartbeat_callback'] = $options['heartbeat_callback'];
         }
 
+        if (!isset($options['client_properties'])) {
+            $options['client_properties'] = [];
+        }
+
+        if (!is_array($options['client_properties'])) {
+            throw new InvalidArgumentException('Client properties must be an array');
+        }
+
         $this->options = $options;
 
         $this->init();
@@ -353,7 +361,7 @@ abstract class AbstractClient
         ], $responseBuffer);
         $responseBuffer->discard(4);
 
-        return $this->connectionStartOk([], "AMQPLAIN", $responseBuffer->read($responseBuffer->getLength()), "en_US");
+        return $this->connectionStartOk($this->options['client_properties'], "AMQPLAIN", $responseBuffer->read($responseBuffer->getLength()), "en_US");
     }
 
     /**


### PR DESCRIPTION
Hey there 👋!

Thank you for providing this library, I'm currently trying it out by porting an existing worker to it and enjoying the experience so far!

One feature I was missing was setting client properties and capabilities, for example, to provide a connection name to more easily identify connections to a server.

* https://www.rabbitmq.com/connections.html#capabilities
* https://www.rabbitmq.com/connections.html#client-provided-names

Enabling Bunny to set client properties is what I'd like to propose with this PR.

```php
$connection = [
    'host'              => 'HOSTNAME',
    'vhost'             => 'VHOST',    // The default vhost is /
    'user'              => 'USERNAME', // The default user is guest
    'password'          => 'PASSWORD', // The default password is guest
    'client_properties' => [
        'connection_name' => 'It works!',
    ],
];
```

<table>
<tr>
	<th>Without connection name
	<th>With connection name
<tr>
	<td><img alt="without_connection_name" src="https://user-images.githubusercontent.com/67554/215208751-2c1ec750-0f26-4924-a30e-745fee40aa0b.png">
    <td><img alt="with_connection_name" src="https://user-images.githubusercontent.com/67554/215208758-8f3b38b3-b4f5-41b4-b3c8-435a645955a0.png">
</table>

I looked if there was a meaningful way to add a test for this, but I'm honestly not sure how to prove that the connection name really is set - all I have are the screenshots above and my word 😅.

I'd appreciate your feedback and am happy to make the needed adjustments to make a merge possible.

:octocat: 