### PR TITLE
Add ability to use otherwise() in connection stage

### DIFF
--- a/src/Bunny/ClientMethods.php
+++ b/src/Bunny/ClientMethods.php
@@ -292,6 +292,9 @@ trait ClientMethods
                         $deferred->reject(new ClientException($frame->replyText, $frame->replyCode));
                     });
                     return true;
+                } elseif ($frame instanceof \Throwable) {
+                    $deferred->reject(new ClientException($frame->getMessage(), Constants::STATUS_ACCESS_REFUSED));
+                    return true;                    
                 }
                 return false;
             });


### PR DESCRIPTION
In the function awaitConnectionTune I added interception of all exceptions to be able to process in reject. like this:
Connection = (new Client())->connect()->then()->otherwise();