### PR TITLE
Add PHPStan to the project and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ jobs:
       - uses: actions/checkout@v2
       - id: supported-versions-matrix
         uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
+  static-anylsis:
+    name: "Run static analysis"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: mbstring, ctype, iconv, bcmath, filter, json
+          tools: composer
+      - name: Install Dependencies
+        uses: ramsey/composer-install@v2
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan analyze src --level 0
   test:
     name: "Run Tests on PHP ${{ matrix.php }} against RabbitMQ ${{ matrix.rabbitmq }} (Composer: ${{ matrix.composer }}; TLS: ${{ matrix.ssl_test }})"
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "ext-pcntl": "*",
         "phpunit/phpunit": "^9.5 || ^7.5.20",
-        "symfony/process": "^6.1 || ^4.4"
+        "symfony/process": "^6.1 || ^4.4",
+        "phpstan/phpstan": "^1.10"
     },
     "suggest": {
         "ext-pcntl": "For using synchronous AMQP/RabbitMQ client"

--- a/src/Bunny/Protocol/AbstractFrame.php
+++ b/src/Bunny/Protocol/AbstractFrame.php
@@ -18,6 +18,7 @@ namespace Bunny\Protocol;
  *      uint8    uint16      uint32        size octets       uint8
  *
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ * @phpstan-consistent-constructor
  */
 abstract class AbstractFrame
 {

--- a/src/Bunny/Protocol/ContentHeaderFrame.php
+++ b/src/Bunny/Protocol/ContentHeaderFrame.php
@@ -17,6 +17,7 @@ use Bunny\Constants;
  *
  *
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ * @phpstan-consistent-constructor
  */
 class ContentHeaderFrame extends AbstractFrame
 {


### PR DESCRIPTION
Hey there 👋 

I wanted to add a more precise definition of the callbacks passed to the `Channel::consume()` and `Channel::run()` method, when I saw that PHPStan was not in the project and I could not find any other kind of static code analysis. I would like to clean some things up (mostly adding missing types, and especially add the callback signature), so to begin with I thought it might be a good idea to bring PHPStan in the CI, WDYT?

I would like to keep this PR small, so I would start adding cleanups in a separate PR, if this is okay with you.

WDYT?