### PR TITLE
Add support of bytes type of AMQP field

### DIFF
--- a/src/Bunny/Constants.php
+++ b/src/Bunny/Constants.php
@@ -251,4 +251,6 @@ final class Constants
 
     const FIELD_NULL = 0x56; // 'V'
 
+    const FIELD_BYTES = 0x78; // 'x'
+
 }

--- a/src/Bunny/Protocol/ProtocolReader.php
+++ b/src/Bunny/Protocol/ProtocolReader.php
@@ -262,6 +262,7 @@ class ProtocolReader
             case Constants::FIELD_SHORT_STRING:
                 return $buffer->consume($buffer->consumeUint8());
             case Constants::FIELD_LONG_STRING:
+            case Constants::FIELD_BYTES:
                 return $buffer->consume($buffer->consumeUint32());
             case Constants::FIELD_ARRAY:
                 return $this->consumeArray($buffer);


### PR DESCRIPTION
Add support of bytes type of AMQP field.

I got error "Unhandled field type 0x78 ('x')" and found fix in php-amqplib

https://github.com/php-amqplib/php-amqplib/blob/6bf2e5c49759fc386a4988f3af1761cbfb63d367/PhpAmqpLib/Wire/AMQPReader.php#L402