### PR TITLE
Add .github, examples and docker to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
+/.github/ export-ignore
 /benchmark/ export-ignore
+/docker/ export-ignore
+/examples/ export-ignore
 /spec/ export-ignore
 /test/ export-ignore
 /tutorial  export-ignore
-/.travis.yml export-ignore
-/phpunit.xml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.github/ export-ignore
-/docker/ export-ignore
-/examples/ export-ignore
+/docker-compose.yml export-ignore
+/phpunit.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 /phpunit.xml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.github/ export-ignore
+/docker/ export-ignore
+/examples/ export-ignore


### PR DESCRIPTION
Hi @WyriHaximus 

I saw a gitattribute were added but I think some entries are missing
- Examples are not mandatory when downloading the libraries
- The docker folder is for local development if I understand correctly
- the .github folder is not needed