### PR TITLE
InvalidArgumentException on heartbeat set to zero

### DIFF
--- a/src/Bunny/AbstractClient.php
+++ b/src/Bunny/AbstractClient.php
@@ -130,6 +130,8 @@ abstract class AbstractClient
 
         if (!isset($options["heartbeat"])) {
             $options["heartbeat"] = 60.0;
+        } elseif ($options["heartbeat"] == 0) {
+            throw new InvalidArgumentException("Heartbeat can not be zero.");
         } elseif ($options["heartbeat"] >= 2**15) {
             throw new InvalidArgumentException("Heartbeat too high: the value is a signed int16.");
         }


### PR DESCRIPTION
Throws InvalidArgumentException on zero heartbeat. 

Setting heartbeat to zero usually means heartbeat is disabled (or value from the server is used) - i.e. https://github.com/php-amqplib/RabbitMqBundle/issues/552 

Currently, setting heartbeat to zero in bunny causes DoS on the rabbit server - in my case it caused 1 Mpps rate with 1 Gbps traffic and the CPU load has been maxed out on our rabbit server. So no one realistically wants this behavior. 

It took me quite some time to debug this (initially I thought it was caused due to forking and some async issues). 
I believe I may not be the only one setting this to zero thinking it would disable the heartbeat like on other implementations. 