### PR TITLE
Add support for setting client properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ Note: invalid SSL configuration will cause connection failure.
 
 See also [common configuration variants](examples/ssl/).
 
+### Providing client properties
+
+Client Connections can [present their capabilities](https://www.rabbitmq.com/connections.html#capabilities) to
+a server by presenting an optional `client_properties` table when establishing a connection.
+
+For example, a connection name may be provided by setting the
+[`connection_name` property](https://www.rabbitmq.com/connections.html#client-provided-names):
+
+```php
+$connection = [
+    'host'              => 'HOSTNAME',
+    'vhost'             => 'VHOST',    // The default vhost is /
+    'user'              => 'USERNAME', // The default user is guest
+    'password'          => 'PASSWORD', // The default password is guest
+    'client_properties' => [
+        'connection_name' => 'My connection',
+    ],
+];
+
+$bunny = new Client($connection);
+$bunny->connect();
+```
+
 ### Publish a message
 
 Now that we have a connection with the server we need to create a channel and declare a queue to communicate over before we can publish a message, or subscribe to a queue for that matter.

--- a/src/Client.php
+++ b/src/Client.php
@@ -118,11 +118,17 @@ class Client implements ClientInterface
             unset($options['heartbeat_callback']);
         }
 
-
         if (isset($options['ssl']) && is_array($options['ssl'])) {
             $options['tls'] = $options['ssl'];
         }
 
+        if (!isset($options['client_properties'])) {
+            $options['client_properties'] = [];
+        }
+
+        if (!is_array($options['client_properties'])) {
+            throw new \InvalidArgumentException('Client properties must be an array');
+        }
 
         $this->options = $options;
         $this->connector = new Connector($this->options);
@@ -233,7 +239,7 @@ class Client implements ClientInterface
         ], $responseBuffer);
         $responseBuffer->discard(4);
 
-        $this->connection->connectionStartOk($responseBuffer->read($responseBuffer->getLength()), [], 'AMQPLAIN', 'en_US');
+        $this->connection->connectionStartOk($responseBuffer->read($responseBuffer->getLength()), $this->options['client_properties'], 'AMQPLAIN', 'en_US');
     }
 
     /**

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -54,6 +54,15 @@ class ClientTest extends TestCase
         $this->assertFalse($client->isConnected());
     }
 
+    public function testConnectWithInvalidClientProperties()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->helper->createClient([
+            'client_properties' => 'not an array'
+        ]);
+    }
+
     public function testConnectFailure()
     {
         $this->expectException(ClientException::class);


### PR DESCRIPTION
As a follow-up to #132 , this PR adds support for setting client properties and capabilities, as described in

* https://www.rabbitmq.com/connections.html#capabilities
* https://www.rabbitmq.com/connections.html#client-provided-names

```php
$connection = [
    'host'              => 'HOSTNAME',
    'vhost'             => 'VHOST',    // The default vhost is /
    'user'              => 'USERNAME', // The default user is guest
    'password'          => 'PASSWORD', // The default password is guest
    'client_properties' => [
        'connection_name' => 'It works!',
    ],
];
```

<table>
<tr>
	<th>Without connection name
	<th>With connection name
<tr>
	<td><img alt="without_connection_name" src="https://user-images.githubusercontent.com/67554/215208751-2c1ec750-0f26-4924-a30e-745fee40aa0b.png">
    <td><img alt="with_connection_name" src="https://user-images.githubusercontent.com/67554/215208758-8f3b38b3-b4f5-41b4-b3c8-435a645955a0.png">
</table>

:octocat: 