### PR TITLE
Replace `*Enum` classes with a native Enums

### DIFF
--- a/src/Channel.php
+++ b/src/Channel.php
@@ -81,8 +81,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
     /** @var Buffer */
     private $bodyBuffer;
 
-    /** @var int */
-    private $state = ChannelStateEnum::READY;
+    private ChannelState $state = ChannelState::Ready;
 
     /** @var int */
     private $mode = ChannelModeEnum::REGULAR;
@@ -202,16 +201,16 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function close(int $replyCode = 0, string $replyText = ""): void
     {
-        if ($this->state === ChannelStateEnum::CLOSED) {
+        if ($this->state === ChannelState::Closed) {
             throw new ChannelException("Trying to close already closed channel #{$this->channelId}.");
         }
 
-        if ($this->state === ChannelStateEnum::CLOSING) {
+        if ($this->state === ChannelState::Closing) {
             await($this->closePromise);
             return;
         }
 
-        $this->state = ChannelStateEnum::CLOSING;
+        $this->state = ChannelState::Closing;
 
         $this->connection->channelClose($this->channelId, $replyCode, 0, 0, $replyText);
         $this->closeDeferred = new Deferred();
@@ -279,12 +278,12 @@ class Channel implements ChannelInterface, EventEmitterInterface
             return null;
 
         } elseif ($response instanceof MethodBasicGetOkFrame) {
-            $this->state = ChannelStateEnum::AWAITING_HEADER;
+            $this->state = ChannelState::AwaitingHeader;
 
             $headerFrame = $this->connection->awaitContentHeader($this->getChannelId());
             $this->headerFrame = $headerFrame;
             $this->bodySizeRemaining = $headerFrame->bodySize;
-            $this->state = ChannelStateEnum::AWAITING_BODY;
+            $this->state = ChannelState::AwaitingBody;
 
             while ($this->bodySizeRemaining > 0) {
                 $bodyFrame = $this->connection->awaitContentBody($this->getChannelId());
@@ -293,13 +292,13 @@ class Channel implements ChannelInterface, EventEmitterInterface
                 $this->bodySizeRemaining -= $bodyFrame->payloadSize;
 
                 if ($this->bodySizeRemaining < 0) {
-                    $this->state = ChannelStateEnum::ERROR;
+                    $this->state = ChannelState::Error;
                     $this->connection->disconnect(Constants::STATUS_SYNTAX_ERROR, $errorMessage = "Body overflow, received " . (-$this->bodySizeRemaining) . " more bytes.");
                     throw new ChannelException($errorMessage);
                 }
             }
 
-            $this->state = ChannelStateEnum::READY;
+            $this->state = ChannelState::Ready;
 
             $message = new Message(
                 null,
@@ -415,26 +414,26 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function onFrameReceived(AbstractFrame $frame): void
     {
-        if ($this->state === ChannelStateEnum::ERROR) {
+        if ($this->state === ChannelState::Error) {
             throw new ChannelException("Channel in error state.");
         }
 
-        if ($this->state === ChannelStateEnum::CLOSED) {
+        if ($this->state === ChannelState::Closed) {
             throw new ChannelException("Received frame #{$frame->type} on closed channel #{$this->channelId}.");
         }
 
         if ($frame instanceof MethodFrame) {
-            if ($this->state === ChannelStateEnum::CLOSING && !($frame instanceof MethodChannelCloseOkFrame)) {
+            if ($this->state === ChannelState::Closing && !($frame instanceof MethodChannelCloseOkFrame)) {
                 // drop frames in closing state
                 return;
 
-            } elseif ($this->state !== ChannelStateEnum::READY && !($frame instanceof MethodChannelCloseOkFrame)) {
+            } elseif ($this->state !== ChannelState::Ready && !($frame instanceof MethodChannelCloseOkFrame)) {
                 $currentState = $this->state;
-                $this->state = ChannelStateEnum::ERROR;
+                $this->state = ChannelState::Error;
 
-                if ($currentState === ChannelStateEnum::AWAITING_HEADER) {
+                if ($currentState === ChannelState::AwaitingHeader) {
                     $msg = "Got method frame, expected header frame.";
-                } elseif ($currentState === ChannelStateEnum::AWAITING_BODY) {
+                } elseif ($currentState === ChannelState::AwaitingBody) {
                     $msg = "Got method frame, expected body frame.";
                 } else {
                     throw new \LogicException("Unhandled channel state.");
@@ -446,7 +445,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
             }
 
             if ($frame instanceof MethodChannelCloseOkFrame) {
-                $this->state = ChannelStateEnum::CLOSED;
+                $this->state = ChannelState::Closed;
 
                 if ($this->closeDeferred !== null) {
                     $this->closeDeferred->resolve($this->channelId);
@@ -459,11 +458,11 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
             } elseif ($frame instanceof MethodBasicReturnFrame) {
                 $this->returnFrame = $frame;
-                $this->state = ChannelStateEnum::AWAITING_HEADER;
+                $this->state = ChannelState::AwaitingHeader;
 
             } elseif ($frame instanceof MethodBasicDeliverFrame) {
                 $this->deliverFrame = $frame;
-                $this->state = ChannelStateEnum::AWAITING_HEADER;
+                $this->state = ChannelState::AwaitingHeader;
 
             } elseif ($frame instanceof MethodBasicAckFrame) {
                 foreach ($this->ackCallbacks as $callback) {
@@ -482,17 +481,17 @@ class Channel implements ChannelInterface, EventEmitterInterface
             }
 
         } elseif ($frame instanceof ContentHeaderFrame) {
-            if ($this->state === ChannelStateEnum::CLOSING) {
+            if ($this->state === ChannelState::Closing) {
                 // drop frames in closing state
                 return;
 
-            } elseif ($this->state !== ChannelStateEnum::AWAITING_HEADER) {
+            } elseif ($this->state !== ChannelState::AwaitingHeader) {
                 $currentState = $this->state;
-                $this->state = ChannelStateEnum::ERROR;
+                $this->state = ChannelState::Error;
 
-                if ($currentState === ChannelStateEnum::READY) {
+                if ($currentState === ChannelState::Ready) {
                     $msg = "Got header frame, expected method frame.";
-                } elseif ($currentState === ChannelStateEnum::AWAITING_BODY) {
+                } elseif ($currentState === ChannelState::AwaitingBody) {
                     $msg = "Got header frame, expected content frame.";
                 } else {
                     throw new \LogicException("Unhandled channel state.");
@@ -507,24 +506,24 @@ class Channel implements ChannelInterface, EventEmitterInterface
             $this->bodySizeRemaining = $frame->bodySize;
 
             if ($this->bodySizeRemaining > 0) {
-                $this->state = ChannelStateEnum::AWAITING_BODY;
+                $this->state = ChannelState::AwaitingBody;
             } else {
-                $this->state = ChannelStateEnum::READY;
+                $this->state = ChannelState::Ready;
                 $this->onBodyComplete();
             }
 
         } elseif ($frame instanceof ContentBodyFrame) {
-            if ($this->state === ChannelStateEnum::CLOSING) {
+            if ($this->state === ChannelState::Closing) {
                 // drop frames in closing state
                 return;
 
-            } elseif ($this->state !== ChannelStateEnum::AWAITING_BODY) {
+            } elseif ($this->state !== ChannelState::AwaitingBody) {
                 $currentState = $this->state;
-                $this->state = ChannelStateEnum::ERROR;
+                $this->state = ChannelState::Error;
 
-                if ($currentState === ChannelStateEnum::READY) {
+                if ($currentState === ChannelState::Ready) {
                     $msg = "Got body frame, expected method frame.";
-                } elseif ($currentState === ChannelStateEnum::AWAITING_HEADER) {
+                } elseif ($currentState === ChannelState::AwaitingHeader) {
                     $msg = "Got body frame, expected header frame.";
                 } else {
                     throw new \LogicException("Unhandled channel state.");
@@ -539,11 +538,11 @@ class Channel implements ChannelInterface, EventEmitterInterface
             $this->bodySizeRemaining -= $frame->payloadSize;
 
             if ($this->bodySizeRemaining < 0) {
-                $this->state = ChannelStateEnum::ERROR;
+                $this->state = ChannelState::Error;
                 $this->connection->disconnect(Constants::STATUS_SYNTAX_ERROR, "Body overflow, received " . (-$this->bodySizeRemaining) . " more bytes.");
 
             } elseif ($this->bodySizeRemaining === 0) {
-                $this->state = ChannelStateEnum::READY;
+                $this->state = ChannelState::Ready;
                 $this->onBodyComplete();
             }
 

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -83,8 +83,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
     private ChannelState $state = ChannelState::Ready;
 
-    /** @var int */
-    private $mode = ChannelModeEnum::REGULAR;
+    private ChannelMode $mode = ChannelMode::Regular;
 
     /** @var Deferred */
     private $closeDeferred;
@@ -118,10 +117,8 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
     /**
      * Returns the channel mode.
-     *
-     * @return int
      */
-    public function getMode(): int
+    public function getMode(): ChannelMode
     {
         return $this->mode;
     }
@@ -164,7 +161,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function addAckListener(callable $callback)
     {
-        if ($this->mode !== ChannelModeEnum::CONFIRM) {
+        if ($this->mode !== ChannelMode::Confirm) {
             throw new ChannelException("Ack/nack listener can be added when channel in confirm mode.");
         }
 
@@ -181,7 +178,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function removeAckListener(callable $callback)
     {
-        if ($this->mode !== ChannelModeEnum::CONFIRM) {
+        if ($this->mode !== ChannelMode::Confirm) {
             throw new ChannelException("Ack/nack listener can be removed when channel in confirm mode.");
         }
 
@@ -326,7 +323,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
     {
         $response = $this->publishImpl($body, $headers, $exchange, $routingKey, $mandatory, $immediate);
 
-        if ($this->mode === ChannelModeEnum::CONFIRM) {
+        if ($this->mode === ChannelMode::Confirm) {
             return ++$this->deliveryTag;
         } else {
             return $response;
@@ -348,12 +345,12 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function txSelect(): \Bunny\Protocol\MethodTxSelectOkFrame
     {
-        if ($this->mode !== ChannelModeEnum::REGULAR) {
+        if ($this->mode !== ChannelMode::Regular) {
             throw new ChannelException("Channel not in regular mode, cannot change to transactional mode.");
         }
 
         $response = $this->txSelectImpl();
-        $this->mode = ChannelModeEnum::TRANSACTIONAL;
+        $this->mode = ChannelMode::Transactional;
 
         return $response;
     }
@@ -363,7 +360,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function txCommit(): \Bunny\Protocol\MethodTxCommitOkFrame
     {
-        if ($this->mode !== ChannelModeEnum::TRANSACTIONAL) {
+        if ($this->mode !== ChannelMode::Transactional) {
             throw new ChannelException("Channel not in transactional mode, cannot call 'tx.commit'.");
         }
 
@@ -375,7 +372,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function txRollback(): \Bunny\Protocol\MethodTxRollbackOkFrame
     {
-        if ($this->mode !== ChannelModeEnum::TRANSACTIONAL) {
+        if ($this->mode !== ChannelMode::Transactional) {
             throw new ChannelException("Channel not in transactional mode, cannot call 'tx.rollback'.");
         }
 
@@ -387,7 +384,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function confirmSelect(callable $callback = null, bool $nowait = false): \Bunny\Protocol\MethodConfirmSelectOkFrame
     {
-        if ($this->mode !== ChannelModeEnum::REGULAR) {
+        if ($this->mode !== ChannelMode::Regular) {
             throw new ChannelException("Channel not in regular mode, cannot change to transactional mode.");
         }
 
@@ -399,7 +396,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
     private function enterConfirmMode(callable $callback = null): void
     {
-        $this->mode = ChannelModeEnum::CONFIRM;
+        $this->mode = ChannelMode::Confirm;
         $this->deliveryTag = 0;
 
         if ($callback) {

--- a/src/ChannelInterface.php
+++ b/src/ChannelInterface.php
@@ -19,10 +19,9 @@ interface ChannelInterface
 {
     /**
      * Returns the channel mode.
-     *
-     * @return int
      */
-    public function getMode(): int;
+    public function getMode(): ChannelMode;
+
     /**
      * Listener is called whenever 'basic.return' frame is received with arguments (Message $returnedMessage, MethodBasicReturnFrame $frame)
      *

--- a/src/ChannelMode.php
+++ b/src/ChannelMode.php
@@ -9,24 +9,21 @@ namespace Bunny;
  *
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  */
-final class ChannelModeEnum
+enum ChannelMode
 {
 
     /**
      * Regular AMQP guarantees of published messages delivery.
      */
-    const REGULAR = 1;
+    case Regular;
 
     /**
      * Messages are published after 'tx.commit'.
      */
-    const TRANSACTIONAL = 2;
+    case Transactional;
 
     /**
      * Broker sends asynchronously 'basic.ack's for delivered messages.
      */
-    const CONFIRM = 3;
-
-
-
+    case Confirm;
 }

--- a/src/ChannelState.php
+++ b/src/ChannelState.php
@@ -9,37 +9,35 @@ namespace Bunny;
  *
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  */
-final class ChannelStateEnum
+enum ChannelState
 {
-
     /**
      * Channel is ready to receive messages.
      */
-    const READY = 1;
+    case Ready;
 
     /**
      * Channel got method that is followed by header/content frames and now waits for header frame.
      */
-    const AWAITING_HEADER = 2;
+    case AwaitingHeader;
 
     /**
      * Channel got method and header frame and now waits for body frame.
      */
-    const AWAITING_BODY = 3;
+    case AwaitingBody;
 
     /**
      * An error occurred on channel.
      */
-    const ERROR = 4;
+    case Error;
 
     /**
      * Channel is being closed.
      */
-    const CLOSING = 5;
+    case Closing;
 
     /**
      * Channel has received channel.close-ok frame.
      */
-    const CLOSED = 6;
-
+    case Closed;
 }

--- a/src/ClientState.php
+++ b/src/ClientState.php
@@ -9,32 +9,32 @@ namespace Bunny;
  *
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  */
-final class ClientStateEnum
+enum ClientState
 {
 
     /**
      * Client is not connected. Method connect() hasn't been called yet.
      */
-    const NOT_CONNECTED = 0;
+    case NotConnected;
 
     /**
      * Client is currently connecting to AMQP server.
      */
-    const CONNECTING = 1;
+    case Connecting;
 
     /**
      * Client is connected and ready to communicate.
      */
-    const CONNECTED = 2;
+    case Connected;
 
     /**
      * Client is currently disconnecting from AMQP server.
      */
-    const DISCONNECTING = 3;
+    case Disconnecting;
 
     /**
      * An error has occurred.
      */
-    const ERROR = 4;
+    case Error;
 
 }


### PR DESCRIPTION
```diff
interface ChannelInterface
{
-    public function getMode(): int;
+    public function getMode(): ChannelMode;
}
```
That's a breaking change - I don't know if this is acceptable for 0.6.x but I thought I could give it a try anyway 🤞🏻

:octocat: