### PR TITLE
Remove implicit nullable typehints for PHP 8.4 compatibility

### DIFF
--- a/src/Channel.php
+++ b/src/Channel.php
@@ -382,7 +382,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
     /**
      * Changes channel to confirm mode. Broker then asynchronously sends 'basic.ack's for published messages.
      */
-    public function confirmSelect(callable $callback = null, bool $nowait = false): \Bunny\Protocol\MethodConfirmSelectOkFrame
+    public function confirmSelect(?callable $callback = null, bool $nowait = false): \Bunny\Protocol\MethodConfirmSelectOkFrame
     {
         if ($this->mode !== ChannelMode::Regular) {
             throw new ChannelException("Channel not in regular mode, cannot change to transactional mode.");
@@ -394,7 +394,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
         return $response;
     }
 
-    private function enterConfirmMode(callable $callback = null): void
+    private function enterConfirmMode(?callable $callback = null): void
     {
         $this->mode = ChannelMode::Confirm;
         $this->deliveryTag = 0;

--- a/src/ChannelInterface.php
+++ b/src/ChannelInterface.php
@@ -114,6 +114,6 @@ interface ChannelInterface
     /**
      * Changes channel to confirm mode. Broker then asynchronously sends 'basic.ack's for published messages.
      */
-    public function confirmSelect(callable $callback = null, bool $nowait = false): \Bunny\Protocol\MethodConfirmSelectOkFrame;
+    public function confirmSelect(?callable $callback = null, bool $nowait = false): \Bunny\Protocol\MethodConfirmSelectOkFrame;
 }
 

--- a/test/Library/SynchronousClientHelper.php
+++ b/test/Library/SynchronousClientHelper.php
@@ -14,7 +14,7 @@ final class SynchronousClientHelper extends AbstractClientHelper
      *
      * @return Client
      */
-    public function createClient(array $options = null): Client
+    public function createClient(?array $options = null): Client
     {
         $options = array_merge($this->getDefaultOptions(), $options ?? []);
 


### PR DESCRIPTION
Recently released new PHP 8.4 deprecates implicit nullable parameter definition - eg. float $start = null must be changed to ?float $start = null.

Nullable typehints are are supported since PHP 7.1, so that should be in line with minimum required version in composer.json