### PR TITLE
Support int64 in arguments

### DIFF
--- a/src/Protocol/ProtocolWriter.php
+++ b/src/Protocol/ProtocolWriter.php
@@ -200,8 +200,13 @@ class ProtocolWriter
             $buffer->append($value);
 
         } elseif (is_int($value)) {
-            $buffer->appendUint8(Constants::FIELD_LONG_INT);
-            $buffer->appendInt32($value);
+           if ($value >= -2_147_483_648 && $value <= 2_147_483_647) {
+               $buffer->appendUint8(Constants::FIELD_LONG_INT);
+               $buffer->appendInt32($value);
+           } else {
+               $buffer->appendUint8(Constants::FIELD_LONG_LONG_INT);
+               $buffer->appendInt64($value);
+           }
 
         } elseif (is_bool($value)) {
             $buffer->appendUint8(Constants::FIELD_BOOLEAN);

--- a/src/Protocol/ProtocolWriter.php
+++ b/src/Protocol/ProtocolWriter.php
@@ -200,7 +200,7 @@ class ProtocolWriter
             $buffer->append($value);
 
         } elseif (is_int($value)) {
-           if ($value >= -2_147_483_648 && $value <= 2_147_483_647) {
+           if (PHP_INT_SIZE === 4) {
                $buffer->appendUint8(Constants::FIELD_LONG_INT);
                $buffer->appendInt32($value);
            } else {

--- a/test/Protocol/ProtocolWriterTest.php
+++ b/test/Protocol/ProtocolWriterTest.php
@@ -44,37 +44,46 @@ class ProtocolWriterTest extends TestCase
         $protocolWriter->appendFieldValue($date, $buffer);
     }
 
-    public function test_appendFieldValue_canHandleInt32()
+    /**
+     * @dataProvider provider_appendFieldValue_canHandleInt64
+     */
+    public function test_appendFieldValue_canHandleInt64(int $value, bool $expectedInt64)
     {
         $buffer = $this->createMock(Buffer::class);
         $protocolWriter = new ProtocolWriter();
 
-        $int = 42;
+        if ($expectedInt64) {
+            $buffer->expects($this->once())
+                   ->method('appendUint8')
+                   ->with(Constants::FIELD_LONG_LONG_INT);
+            $buffer->expects($this->once())
+                   ->method('appendInt64')
+                   ->with($value);
+        } else {
+            $buffer->expects($this->once())
+                   ->method('appendUint8')
+                   ->with(Constants::FIELD_LONG_INT);
+            $buffer->expects($this->once())
+                   ->method('appendInt32')
+                   ->with($value);
+        }
 
-        $buffer->expects($this->once())
-               ->method('appendUint8')
-               ->with(Constants::FIELD_LONG_INT);
-        $buffer->expects($this->once())
-               ->method('appendInt32')
-               ->with($int);
-
-        $protocolWriter->appendFieldValue($int, $buffer);
+        $protocolWriter->appendFieldValue($value, $buffer);
     }
 
-    public function test_appendFieldValue_canHandleInt64()
+    /**
+     * @return iterable<array<string,mixed>>
+     */
+    public static function provider_appendFieldValue_canHandleInt64(): iterable
     {
-        $buffer = $this->createMock(Buffer::class);
-        $protocolWriter = new ProtocolWriter();
+        yield [
+            'value' => 42,
+            'expectedInt64' => true,
+        ];
 
-        $int = 2_157_483_647;
-
-        $buffer->expects($this->once())
-               ->method('appendUint8')
-               ->with(Constants::FIELD_LONG_LONG_INT);
-        $buffer->expects($this->once())
-               ->method('appendInt64')
-               ->with($int);
-
-        $protocolWriter->appendFieldValue($int, $buffer);
+        yield [
+            'value' => 2_157_483_647,
+            'expectedInt64' => true,
+        ];
     }
 }

--- a/test/Protocol/ProtocolWriterTest.php
+++ b/test/Protocol/ProtocolWriterTest.php
@@ -43,4 +43,38 @@ class ProtocolWriterTest extends TestCase
 
         $protocolWriter->appendFieldValue($date, $buffer);
     }
+
+    public function test_appendFieldValue_canHandleInt32()
+    {
+        $buffer = $this->createMock(Buffer::class);
+        $protocolWriter = new ProtocolWriter();
+
+        $int = 42;
+
+        $buffer->expects($this->once())
+               ->method('appendUint8')
+               ->with(Constants::FIELD_LONG_INT);
+        $buffer->expects($this->once())
+               ->method('appendInt32')
+               ->with($int);
+
+        $protocolWriter->appendFieldValue($int, $buffer);
+    }
+
+    public function test_appendFieldValue_canHandleInt64()
+    {
+        $buffer = $this->createMock(Buffer::class);
+        $protocolWriter = new ProtocolWriter();
+
+        $int = 2_157_483_647;
+
+        $buffer->expects($this->once())
+               ->method('appendUint8')
+               ->with(Constants::FIELD_LONG_LONG_INT);
+        $buffer->expects($this->once())
+               ->method('appendInt64')
+               ->with($int);
+
+        $protocolWriter->appendFieldValue($int, $buffer);
+    }
 }


### PR DESCRIPTION
When consuming stream queue, you send starting numeric offset value as header argument.

```php
$client = new Client();
$channel = $client->channel();

$channel->consume(consumeCallback(...), "stream-queue-name", arguments: [
    'x-stream-offset' => 2_147_958_060,
]);
```

When offset is larger then limit of `int32`, it starts returning messages from the beginning of the queue due to offset overflow because now any int is encoded like this:

```php
$buffer->appendUint8(Constants::FIELD_LONG_INT);
$buffer->appendInt32($value);
```

The simplest solution is to use `int64` instead, which works for any `int` from PHP code, or (as in this PR) at least support `int64` with `int32` as the default for smaller numbers.

```php
$buffer->appendUint8(Constants::FIELD_LONG_LONG_INT);
$buffer->appendInt64($value);
```

