### PR TITLE
Better typehints

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,6 +27,7 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.AssignmentInCondition.AssignmentInCondition"/>
         <exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
     </rule>
     <rule ref="Generic.Formatting.SpaceAfterNot">
         <properties>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,6 @@ parameters:
 			path: test/ClientTest.php
 			count: 1
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with bool\|int will always evaluate to false\.$#'
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with int\|false will always evaluate to false\.$#'
 			path: test/ClientTest.php
 			count: 1

--- a/src/ChannelInterface.php
+++ b/src/ChannelInterface.php
@@ -10,6 +10,7 @@ use Bunny\Protocol\MethodBasicQosOkFrame;
 use Bunny\Protocol\MethodBasicRecoverOkFrame;
 use Bunny\Protocol\MethodConfirmSelectOkFrame;
 use Bunny\Protocol\MethodExchangeBindOkFrame;
+use Bunny\Protocol\MethodExchangeDeclareOkFrame;
 use Bunny\Protocol\MethodExchangeDeleteOkFrame;
 use Bunny\Protocol\MethodExchangeUnbindOkFrame;
 use Bunny\Protocol\MethodQueueBindOkFrame;
@@ -81,16 +82,22 @@ interface ChannelInterface
 
     /**
      * Acks given message.
+     *
+     * @return false
      */
     public function ack(Message $message, bool $multiple = false): bool;
 
     /**
      * Nacks given message.
+     *
+     * @return false
      */
     public function nack(Message $message, bool $multiple = false, bool $requeue = true): bool;
 
     /**
      * Rejects given message.
+     *
+     * @return false
      */
     public function reject(Message $message, bool $requeue = true): bool;
 
@@ -103,13 +110,17 @@ interface ChannelInterface
      * Published message to given exchange.
      *
      * @param array<string,mixed> $headers
+     *
+     * @return int|false
      */
-    public function publish(string $body, array $headers = [], string $exchange = '', string $routingKey = '', bool $mandatory = false, bool $immediate = false): bool|int;
+    public function publish(string $body, array $headers = [], string $exchange = '', string $routingKey = '', bool $mandatory = false, bool $immediate = false): int|bool;
 
     /**
      * Cancels given consumer subscription.
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodBasicCancelOkFrame : false)
      */
-    public function cancel(string $consumerTag, bool $nowait = false): bool|MethodBasicCancelOkFrame;
+    public function cancel(string $consumerTag, bool $nowait = false): MethodBasicCancelOkFrame|bool;
 
     /**
      * Changes channel to transactional mode. All messages are published to queues only after {@link txCommit()} is called.
@@ -128,78 +139,98 @@ interface ChannelInterface
 
     /**
      * Changes channel to confirm mode. Broker then asynchronously sends 'basic.ack's for published messages.
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodConfirmSelectOkFrame : false)
      */
-    public function confirmSelect(?callable $callback = null, bool $nowait = false): bool|MethodConfirmSelectOkFrame;
+    public function confirmSelect(?callable $callback = null, bool $nowait = false): MethodConfirmSelectOkFrame|bool;
 
     /**
      * Calls basic.qos AMQP method.
      */
-    public function qos(int $prefetchSize = 0, int $prefetchCount = 0, bool $global = false): bool|MethodBasicQosOkFrame;
+    public function qos(int $prefetchSize = 0, int $prefetchCount = 0, bool $global = false): MethodBasicQosOkFrame;
 
     /**
      * Calls queue.declare AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodQueueDeclareOkFrame : false)
      */
-    public function queueDeclare(string $queue = '', bool $passive = false, bool $durable = false, bool $exclusive = false, bool $autoDelete = false, bool $nowait = false, array $arguments = []): bool|MethodQueueDeclareOkFrame;
+    public function queueDeclare(string $queue = '', bool $passive = false, bool $durable = false, bool $exclusive = false, bool $autoDelete = false, bool $nowait = false, array $arguments = []): MethodQueueDeclareOkFrame|bool;
 
     /**
      * Calls queue.bind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodQueueBindOkFrame : false)
      */
-    public function queueBind(string $exchange, string $queue = '', string $routingKey = '', bool $nowait = false, array $arguments = []): bool|MethodQueueBindOkFrame;
+    public function queueBind(string $exchange, string $queue = '', string $routingKey = '', bool $nowait = false, array $arguments = []): MethodQueueBindOkFrame|bool;
 
     /**
      * Calls queue.purge AMQP method.
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodQueuePurgeOkFrame : false)
      */
-    public function queuePurge(string $queue = '', bool $nowait = false): bool|MethodQueuePurgeOkFrame;
+    public function queuePurge(string $queue = '', bool $nowait = false): MethodQueuePurgeOkFrame|bool;
 
     /**
      * Calls queue.delete AMQP method.
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodQueueDeleteOkFrame : false)
      */
-    public function queueDelete(string $queue = '', bool $ifUnused = false, bool $ifEmpty = false, bool $nowait = false): bool|MethodQueueDeleteOkFrame;
+    public function queueDelete(string $queue = '', bool $ifUnused = false, bool $ifEmpty = false, bool $nowait = false): MethodQueueDeleteOkFrame|bool;
 
     /**
      * Calls queue.unbind AMQP method.
      *
      * @param array<string,mixed> $arguments
      */
-    public function queueUnbind(string $exchange, string $queue = '', string $routingKey = '', array $arguments = []): bool|MethodQueueUnbindOkFrame;
+    public function queueUnbind(string $exchange, string $queue = '', string $routingKey = '', array $arguments = []): MethodQueueUnbindOkFrame;
 
     /**
      * Calls exchange.declare AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodExchangeDeclareOkFrame : false)
      */
-    public function exchangeDeclare(string $exchange, string $exchangeType = 'direct', bool $passive = false, bool $durable = false, bool $autoDelete = false, bool $internal = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeDeclareOkFrame;
+    public function exchangeDeclare(string $exchange, string $exchangeType = 'direct', bool $passive = false, bool $durable = false, bool $autoDelete = false, bool $internal = false, bool $nowait = false, array $arguments = []): MethodExchangeDeclareOkFrame|bool;
 
     /**
      * Calls exchange.delete AMQP method.
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodExchangeDeleteOkFrame : false)
      */
-    public function exchangeDelete(string $exchange, bool $ifUnused = false, bool $nowait = false): bool|MethodExchangeDeleteOkFrame;
+    public function exchangeDelete(string $exchange, bool $ifUnused = false, bool $nowait = false): MethodExchangeDeleteOkFrame|bool;
 
     /**
      * Calls exchange.bind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodExchangeBindOkFrame : false)
      */
-    public function exchangeBind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|MethodExchangeBindOkFrame;
+    public function exchangeBind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): MethodExchangeBindOkFrame|bool;
 
     /**
      * Calls exchange.unbind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? \Bunny\Protocol\MethodExchangeUnbindOkFrame : false)
      */
-    public function exchangeUnbind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|MethodExchangeUnbindOkFrame;
+    public function exchangeUnbind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): MethodExchangeUnbindOkFrame|bool;
 
     /**
      * Calls basic.recover-async AMQP method.
+     *
+     * @return false
      */
     public function recoverAsync(bool $requeue = false): bool;
 
     /**
      * Calls basic.recover AMQP method.
      */
-    public function recover(bool $requeue = false): bool|MethodBasicRecoverOkFrame;
+    public function recover(bool $requeue = false): MethodBasicRecoverOkFrame;
 }

--- a/src/ChannelMethods.php
+++ b/src/ChannelMethods.php
@@ -27,6 +27,8 @@ trait ChannelMethods
      * Calls exchange.declare AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeDeclareOkFrame : false)
      */
     public function exchangeDeclare(string $exchange, string $exchangeType = 'direct', bool $passive = false, bool $durable = false, bool $autoDelete = false, bool $internal = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeDeclareOkFrame
     {
@@ -35,6 +37,8 @@ trait ChannelMethods
 
     /**
      * Calls exchange.delete AMQP method.
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeDeleteOkFrame : false)
      */
     public function exchangeDelete(string $exchange, bool $ifUnused = false, bool $nowait = false): bool|Protocol\MethodExchangeDeleteOkFrame
     {
@@ -45,6 +49,8 @@ trait ChannelMethods
      * Calls exchange.bind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeBindOkFrame : false)
      */
     public function exchangeBind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeBindOkFrame
     {
@@ -55,6 +61,8 @@ trait ChannelMethods
      * Calls exchange.unbind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeUnbindOkFrame : false)
      */
     public function exchangeUnbind(string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeUnbindOkFrame
     {
@@ -65,6 +73,8 @@ trait ChannelMethods
      * Calls queue.declare AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodQueueDeclareOkFrame : false)
      */
     public function queueDeclare(string $queue = '', bool $passive = false, bool $durable = false, bool $exclusive = false, bool $autoDelete = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodQueueDeclareOkFrame
     {
@@ -75,6 +85,8 @@ trait ChannelMethods
      * Calls queue.bind AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodQueueBindOkFrame : false)
      */
     public function queueBind(string $exchange, string $queue = '', string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodQueueBindOkFrame
     {
@@ -83,6 +95,8 @@ trait ChannelMethods
 
     /**
      * Calls queue.purge AMQP method.
+     *
+     * @return ($nowait is false ? Protocol\MethodQueuePurgeOkFrame : false)
      */
     public function queuePurge(string $queue = '', bool $nowait = false): bool|Protocol\MethodQueuePurgeOkFrame
     {
@@ -91,6 +105,8 @@ trait ChannelMethods
 
     /**
      * Calls queue.delete AMQP method.
+     *
+     * @return ($nowait is false ? Protocol\MethodQueueDeleteOkFrame : false)
      */
     public function queueDelete(string $queue = '', bool $ifUnused = false, bool $ifEmpty = false, bool $nowait = false): bool|Protocol\MethodQueueDeleteOkFrame
     {
@@ -119,6 +135,8 @@ trait ChannelMethods
      * Calls basic.consume AMQP method.
      *
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodBasicConsumeOkFrame : false)
      */
     public function consume(string $queue = '', string $consumerTag = '', bool $noLocal = false, bool $noAck = false, bool $exclusive = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodBasicConsumeOkFrame
     {
@@ -127,6 +145,8 @@ trait ChannelMethods
 
     /**
      * Calls basic.cancel AMQP method.
+     *
+     * @return ($nowait is false ? Protocol\MethodBasicCancelOkFrame : false)
      */
     public function cancel(string $consumerTag, bool $nowait = false): bool|Protocol\MethodBasicCancelOkFrame
     {
@@ -137,6 +157,8 @@ trait ChannelMethods
      * Calls basic.publish AMQP method.
      *
      * @param array<string,mixed> $headers
+     *
+     * @return false
      */
     public function publish(string $body, array $headers = [], string $exchange = '', string $routingKey = '', bool $mandatory = false, bool $immediate = false): bool
     {
@@ -153,6 +175,8 @@ trait ChannelMethods
 
     /**
      * Calls basic.ack AMQP method.
+     *
+     * @return false
      */
     public function ack(int $deliveryTag = 0, bool $multiple = false): bool
     {
@@ -161,6 +185,8 @@ trait ChannelMethods
 
     /**
      * Calls basic.reject AMQP method.
+     *
+     * @return false
      */
     public function reject(int $deliveryTag, bool $requeue = true): bool
     {
@@ -169,6 +195,8 @@ trait ChannelMethods
 
     /**
      * Calls basic.recover-async AMQP method.
+     *
+     * @return false
      */
     public function recoverAsync(bool $requeue = false): bool
     {
@@ -185,6 +213,8 @@ trait ChannelMethods
 
     /**
      * Calls basic.nack AMQP method.
+     *
+     * @return false
      */
     public function nack(int $deliveryTag = 0, bool $multiple = false, bool $requeue = true): bool
     {
@@ -217,6 +247,8 @@ trait ChannelMethods
 
     /**
      * Calls confirm.select AMQP method.
+     *
+     * @return ($nowait is false ? Protocol\MethodConfirmSelectOkFrame : false)
      */
     public function confirmSelect(bool $nowait = false): bool|Protocol\MethodConfirmSelectOkFrame
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -232,6 +232,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $clientProperties
+     *
+     * @return false
      */
     public function connectionStartOk(string $response, array $clientProperties = [], string $mechanism = 'PLAIN', string $locale = 'en_US'): bool
     {
@@ -278,6 +280,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function connectionSecureOk(string $response): bool
     {
         $buffer = $this->writeBuffer;
@@ -317,6 +322,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function connectionTuneOk(int $channelMax = 0, int $frameMax = 0, int $heartbeat = 0): bool
     {
         $buffer = $this->writeBuffer;
@@ -414,6 +422,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function connectionCloseOk(): bool
     {
         $buffer = $this->writeBuffer;
@@ -586,6 +597,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function channelFlowOk(int $channel, bool $active): bool
     {
         $buffer = $this->writeBuffer;
@@ -630,6 +644,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function channelClose(int $channel, int $replyCode, int $closeClassId, int $closeMethodId, string $replyText = ''): bool
     {
         $buffer = $this->writeBuffer;
@@ -678,6 +695,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function channelCloseOk(int $channel): bool
     {
         $buffer = $this->writeBuffer;
@@ -769,6 +789,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeDeclareOkFrame : false)
      */
     public function exchangeDeclare(int $channel, string $exchange, string $exchangeType = 'direct', bool $passive = false, bool $durable = false, bool $autoDelete = false, bool $internal = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeDeclareOkFrame
     {
@@ -825,6 +847,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return ($nowait is false ? Protocol\MethodExchangeDeleteOkFrame : false)
+     */
     public function exchangeDelete(int $channel, string $exchange, bool $ifUnused = false, bool $nowait = false): bool|Protocol\MethodExchangeDeleteOkFrame
     {
         $buffer = $this->writeBuffer;
@@ -878,6 +903,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeBindOkFrame : false)
      */
     public function exchangeBind(int $channel, string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeBindOkFrame
     {
@@ -938,6 +965,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodExchangeUnbindOkFrame : false)
      */
     public function exchangeUnbind(int $channel, string $destination, string $source, string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodExchangeUnbindOkFrame
     {
@@ -998,6 +1027,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodQueueDeclareOkFrame : false)
      */
     public function queueDeclare(int $channel, string $queue = '', bool $passive = false, bool $durable = false, bool $exclusive = false, bool $autoDelete = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodQueueDeclareOkFrame
     {
@@ -1054,6 +1085,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodQueueBindOkFrame : false)
      */
     public function queueBind(int $channel, string $exchange, string $queue = '', string $routingKey = '', bool $nowait = false, array $arguments = []): bool|Protocol\MethodQueueBindOkFrame
     {
@@ -1112,6 +1145,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return ($nowait is false ? Protocol\MethodQueuePurgeOkFrame : false)
+     */
     public function queuePurge(int $channel, string $queue = '', bool $nowait = false): bool|Protocol\MethodQueuePurgeOkFrame
     {
         $buffer = $this->writeBuffer;
@@ -1163,6 +1199,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return ($nowait is false ? Protocol\MethodQueueDeleteOkFrame : false)
+     */
     public function queueDelete(int $channel, string $queue = '', bool $ifUnused = false, bool $ifEmpty = false, bool $nowait = false): bool|Protocol\MethodQueueDeleteOkFrame
     {
         $buffer = $this->writeBuffer;
@@ -1317,6 +1356,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $arguments
+     *
+     * @return ($nowait is false ? Protocol\MethodBasicConsumeOkFrame : false)
      */
     public function consume(int $channel, string $queue = '', string $consumerTag = '', bool $noLocal = false, bool $noAck = false, bool $exclusive = false, bool $nowait = false, array $arguments = []): bool|Protocol\MethodBasicConsumeOkFrame
     {
@@ -1373,6 +1414,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return ($nowait is false ? Protocol\MethodBasicCancelOkFrame : false)
+     */
     public function cancel(int $channel, string $consumerTag, bool $nowait = false): bool|Protocol\MethodBasicCancelOkFrame
     {
         $buffer = $this->writeBuffer;
@@ -1425,6 +1469,8 @@ final class Connection
 
     /**
      * @param array<string,mixed> $headers
+     *
+     * @return false
      */
     public function publish(int $channel, string $body, array $headers = [], string $exchange = '', string $routingKey = '', bool $mandatory = false, bool $immediate = false): bool
     {
@@ -1765,6 +1811,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function ack(int $channel, int $deliveryTag = 0, bool $multiple = false): bool
     {
         $buffer = $this->writeBuffer;
@@ -1810,6 +1859,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function reject(int $channel, int $deliveryTag, bool $requeue = true): bool
     {
         $buffer = $this->writeBuffer;
@@ -1826,6 +1878,9 @@ final class Connection
         return false;
     }
 
+    /**
+     * @return false
+     */
     public function recoverAsync(int $channel, bool $requeue = false): bool
     {
         $buffer = $this->writeBuffer;
@@ -1885,6 +1940,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return false
+     */
     public function nack(int $channel, int $deliveryTag = 0, bool $multiple = false, bool $requeue = true): bool
     {
         $buffer = $this->writeBuffer;
@@ -2059,6 +2117,9 @@ final class Connection
         return await($deferred->promise());
     }
 
+    /**
+     * @return ($nowait is false ? Protocol\MethodConfirmSelectOkFrame : false)
+     */
     public function confirmSelect(int $channel, bool $nowait = false): bool|Protocol\MethodConfirmSelectOkFrame
     {
         $buffer = $this->writeBuffer;


### PR DESCRIPTION
Use `phpstan` [conditional return types](https://phpstan.org/blog/phpstan-1-6-0-with-conditional-return-types) to better typehint of returned values.

Ignoring `phpcs` rule `SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation` for
```
/**
 * @return false
 */
public function connectionCloseOk(): bool
```
I would use `connectionCloseOk(): false`, but it can be used as standalone type only since PHP 8.2.