### PR TITLE
PHP 8.4: Implicitly marking parameter X as nullable is deprecated, the explicit nullable type must be used instead in

### DIFF
--- a/src/Bunny/Async/Client.php
+++ b/src/Bunny/Async/Client.php
@@ -64,7 +64,7 @@ class Client extends AbstractClient
      * @param LoopInterface $eventLoop
      * @param array $options see {@link AbstractClient} for available options
      */
-    public function __construct(LoopInterface $eventLoop = null, array $options = [])
+    public function __construct(?LoopInterface $eventLoop = null, array $options = [])
     {
         $options["async"] = true;
         parent::__construct($options);

--- a/src/Bunny/Channel.php
+++ b/src/Bunny/Channel.php
@@ -523,7 +523,7 @@ class Channel
      * @param bool $nowait
      * @return Protocol\MethodConfirmSelectOkFrame|PromiseInterface
      */
-    public function confirmSelect(callable $callback = null, $nowait = false)
+    public function confirmSelect(?callable $callback = null, $nowait = false)
     {
         if ($this->mode !== ChannelModeEnum::REGULAR) {
             throw new ChannelException("Channel not in regular mode, cannot change to transactional mode.");
@@ -543,7 +543,7 @@ class Channel
         }
     }
 
-    private function enterConfirmMode(callable $callback = null)
+    private function enterConfirmMode(?callable $callback = null)
     {
         $this->mode = ChannelModeEnum::CONFIRM;
         $this->deliveryTag = 0;

--- a/test/Library/AsynchronousClientHelper.php
+++ b/test/Library/AsynchronousClientHelper.php
@@ -15,7 +15,7 @@ final class AsynchronousClientHelper extends AbstractClientHelper
      *
      * @return Client
      */
-    public function createClient(LoopInterface $loop, array $options = null): Client
+    public function createClient(LoopInterface $loop, ?array $options = null): Client
     {
         $options = array_merge($this->getDefaultOptions(), $options ?? []);
 

--- a/test/Library/SynchronousClientHelper.php
+++ b/test/Library/SynchronousClientHelper.php
@@ -14,7 +14,7 @@ final class SynchronousClientHelper extends AbstractClientHelper
      *
      * @return Client
      */
-    public function createClient(array $options = null): Client
+    public function createClient(?array $options = null): Client
     {
         $options = array_merge($this->getDefaultOptions(), $options ?? []);
 


### PR DESCRIPTION
@jakubkulhan Hi, could you check it, please and merge it/tag it? 🙏