### PR TITLE
[RFC][0.6.x] Helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "platform": {
+            "php": "8.1.13"
         }
     }
 }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny;
+
+use Bunny\Helper\Async;
+use Bunny\Helper\Sync;
+
+final class Helper
+{
+    public static function async(Configuration $configuration): Async
+    {
+        return new Async($configuration);
+    }
+
+    public static function sync(Configuration $configuration): Sync
+    {
+        return new Sync(self::async($configuration));
+    }
+}

--- a/src/Helper/Async.php
+++ b/src/Helper/Async.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Helper;
+
+use Bunny\Client;
+use Bunny\ClientInterface;
+use Bunny\Configuration;
+use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\Timer\sleep;
+use function React\Promise\race;
+
+final class Async
+{
+    private const TIMEOUT = PublishMessage::TIMEOUT;
+    private readonly CLientInterface $client;
+
+    public function __construct(
+        Configuration|ClientInterface $configurationOrClient,
+    ) {
+        if ($configurationOrClient instanceof Configuration) {
+            $this->client = new Client($configurationOrClient);
+        } else {
+            $this->client = $configurationOrClient;
+        }
+    }
+
+    /**
+     * Open connection, published message to given exchange, and close the connection before returning.
+     *
+     * @param array<string,mixed> $headers
+     *
+     * @return int|false
+     */
+    public function publish(
+        string $body,
+        array $headers = [],
+        string $exchange = '',
+        string $routingKey = '',
+        bool $mandatory = false,
+        bool $immediate = false,
+        float $timeout = self::TIMEOUT,
+    ): int|bool {
+        $promises = [];
+        $result = $promises[] = async(function (
+            PublishMessage $message,
+        ): int|bool {
+            $channel = $this->client->channel();
+            $outCome = $channel->publish($message->body, $message->headers, $message->exchange, $message->routingKey, $message->mandatory, $message->immediate);
+            Loop::futureTick(async(function (): bool {
+                $this->client->disconnect();
+
+                return true;
+            }));
+
+            return $outCome;
+        })(
+            new PublishMessage(
+                $body,
+                $headers,
+                $exchange,
+                $routingKey,
+                $mandatory,
+                $immediate,
+            ),
+        );
+        $promises[] = sleep($timeout);
+
+        await(race($promises));
+
+        return await($result);
+    }
+
+    /**
+     * Open connection, get a single message (or nothing if it's empty) from a queue, and close the connection before returning.
+     */
+    public function get(
+        string $queue = '',
+        bool $noAck = false,
+        float $timeout = self::TIMEOUT,
+    ): Message|null {
+        $promises = [];
+        $result = $promises[] = async(function (
+            string $queue,
+            bool $noAck,
+        ): Message|null {
+            $channel = $this->client->channel();
+            $outCome = $channel->get($queue, $noAck);
+            Loop::futureTick(async(function (): bool {
+                $this->client->disconnect();
+
+                return true;
+            }));
+
+            return $outCome;
+        })(
+            $queue,
+            $noAck,
+        );
+        $promises[] = sleep($timeout);
+
+        await(race($promises));
+
+        return await($result);
+    }
+
+    /**
+     * Open connection, get a single message (or nothing if it's empty) from a queue, and close the connection before returning.
+     *
+     * @param array<string,mixed> $arguments
+     * @param positive-int        $concurrency
+     *
+     * @return iterable<Message>
+     */
+    public function iterate(
+        string $queue = '',
+        string $consumerTag = '',
+        bool $noLocal = false,
+        bool $noAck = false,
+        bool $exclusive = false,
+        bool $nowait = false,
+        array $arguments = [],
+        int $concurrency = 1,
+    ): iterable {
+        return new IterableSubscription($this->client, $queue, $consumerTag, $noLocal, $noAck, $exclusive, $nowait, $arguments, $concurrency);
+    }
+}

--- a/src/Helper/IterableSubscription.php
+++ b/src/Helper/IterableSubscription.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Helper;
+
+use Bunny\ChannelInterface;
+use Bunny\ClientInterface;
+use Bunny\Message;
+use Iterator;
+use React\EventLoop\Loop;
+use React\Promise\Deferred;
+use SplQueue;
+use function React\Async\async;
+use function React\Async\await;
+
+/**
+ * @implements Iterator<mixed, Message>
+ */
+final class IterableSubscription implements Iterator
+{
+    /**
+     * @var SplQueue<Message>
+     */
+    private readonly SplQueue $queue;
+    private readonly ChannelInterface $channel;
+    private readonly string $consumerTag;
+    /**
+     * @var Deferred<bool>|null
+     */
+    private Deferred|null $valid = null;
+    private bool $completed      = false;
+    private int $key             = 0;
+
+    /**
+     * @param array<string,mixed> $arguments
+     * @param positive-int        $concurrency
+     */
+    public function __construct(
+        private readonly ClientInterface $client,
+        string $queue = '',
+        string $consumerTag = '',
+        bool $noLocal = false,
+        bool $noAck = false,
+        bool $exclusive = false,
+        bool $nowait = false,
+        array $arguments = [],
+        int $concurrency = 1,
+    ) {
+        $this->queue      = new SplQueue();
+        $this->channel = $this->client->channel();
+        $this->consumerTag = $this->channel->consume(
+            function (mixed $value): void {
+                $this->push($value);
+            },
+            $queue,
+            $consumerTag,
+            $noLocal,
+            $noAck,
+            $exclusive,
+            $nowait,
+            $arguments,
+            $concurrency,
+        )->consumerTag;
+    }
+
+    public function __destruct()
+    {
+        $this->break();
+    }
+
+    public function break(): void
+    {
+        Loop::futureTick(async(function (): void {
+            $this->channel->cancel($this->consumerTag);
+        }));
+        $this->completed = true;
+    }
+
+    private function push(mixed $value): void
+    {
+        $this->queue->enqueue($value);
+        if ($this->valid === null) {
+            return;
+        }
+
+        $valid       = $this->valid;
+        $this->valid = null;
+        $valid->resolve(true);
+    }
+
+    // phpcs:disable
+    /**
+     * @return mixed
+     */
+    public function current(): mixed
+    {
+        return $this->queue->dequeue();
+    }
+    // phpcs:enable
+
+    public function next(): void
+    {
+        // no-op
+    }
+
+    // phpcs:disable
+    /**
+     * @return mixed
+     */
+    public function key(): mixed
+    {
+        return $this->key++;
+    }
+    // phpcs:enable
+
+    public function valid(): bool
+    {
+        if ($this->queue->count() > 0) {
+            return true;
+        }
+
+        if (!$this->completed) {
+            $this->valid = new Deferred();
+
+            return await($this->valid->promise());
+        }
+
+        return false;
+    }
+
+    public function rewind(): void
+    {
+        // no-op
+    }
+}

--- a/src/Helper/PublishMessage.php
+++ b/src/Helper/PublishMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Helper;
+
+final class PublishMessage
+{
+    public const TIMEOUT = 10.0;
+
+    /**
+     * @param array<string,mixed> $headers
+     */
+    public function __construct(
+        public readonly string $body,
+        public readonly array $headers = [],
+        public readonly string $exchange = '',
+        public readonly string $routingKey = '',
+        public readonly bool $mandatory = false,
+        public readonly bool $immediate = false,
+        public readonly float $timeout = self::TIMEOUT,
+    ) {
+    }
+}

--- a/src/Helper/Sync.php
+++ b/src/Helper/Sync.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Helper;
+
+use React\EventLoop\Loop;
+use React\Promise\Deferred;
+use Throwable;
+use function React\Async\async;
+use function React\Async\await;
+
+final class Sync
+{
+    private const TIMEOUT = PublishMessage::TIMEOUT;
+
+    public function __construct(
+        private readonly Async $async,
+    ) {
+    }
+
+    /**
+     * Open connection, published message to given exchange, and close the connection before returning.
+     *
+     * @param array<string,mixed> $headers
+     *
+     * @return int|false
+     */
+    public function publish(
+        string $body,
+        array $headers = [],
+        string $exchange = '',
+        string $routingKey = '',
+        bool $mandatory = false,
+        bool $immediate = false,
+        float $timeout = self::TIMEOUT,
+    ): int|bool {
+        $deferred = new Deferred();
+        Loop::futureTick(async(function () use ($body, $headers, $exchange, $routingKey, $mandatory, $immediate, $timeout, $deferred): void {
+            try {
+                $result = $this->async->publish($body, $headers, $exchange, $routingKey, $mandatory, $immediate, $timeout);
+
+                Loop::futureTick(static function (): void {
+                    Loop::stop();
+                });
+
+                $deferred->resolve($result);
+            } catch (Throwable $exception) {
+                Loop::futureTick(static function (): void {
+                    Loop::stop();
+                });
+
+                $deferred->reject($exception);
+            }
+        }));
+
+        Loop::run();
+
+        return await($deferred->promise());
+    }
+}

--- a/test/Helper/AsyncTest.php
+++ b/test/Helper/AsyncTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Test\Helper;
+
+use Bunny\Channel;
+use Bunny\Client;
+use Bunny\Configuration;
+use Bunny\Helper;
+use Bunny\Message;
+use Bunny\Test\Library\ClientHelper;
+use Bunny\Test\Library\Environment;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\Loop;
+use React\Promise\Deferred;
+use WyriHaximus\React\PHPUnit\RunTestsInFibersTrait;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\Timer\sleep;
+
+class AsyncTest extends TestCase
+{
+    use RunTestsInFibersTrait;
+
+    private ClientHelper $helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->helper = new ClientHelper();
+    }
+
+    public function testPublish(): void
+    {
+        /**
+         * @var Deferred<string> $deferred
+         */
+        $deferred = new Deferred();
+        $c = $this->helper->createClient();
+        $a = Helper::async(Configuration::fromDSN(Environment::getTestRabbitMqConnectionUri()));
+
+        $ch = $c->connect()->channel();
+        self::assertTrue($c->isConnected());
+        $ch->queueDeclare('test_queue', false, false, false, true);
+        self::assertTrue($c->isConnected());
+        $ch->consume(static function (Message $msg, Channel $ch, Client $c) use ($deferred): void {
+            $deferred->resolve($msg->content);
+        });
+        self::assertTrue($c->isConnected());
+        $a->publish('hi', [], '', 'test_queue');
+        self::assertEquals('hi', await($deferred->promise()));
+
+        self::assertTrue($c->isConnected());
+        $c->disconnect();
+        self::assertFalse($c->isConnected());
+    }
+
+    public function testGet(): void
+    {
+        $asyncHelper = Helper::async(Configuration::fromDSN(Environment::getTestRabbitMqConnectionUri()));
+        $client = $this->helper->createClient();
+        $client->connect();
+        $channel = $client->channel();
+
+        $channel->queueDeclare('get_test');
+        $channel->publish('.', [], '', 'get_test');
+
+        $message1 = $asyncHelper->get('get_test', true);
+        self::assertNotNull($message1);
+        self::assertInstanceOf(Message::class, $message1);
+        self::assertEquals($message1->exchange, '');
+        self::assertEquals($message1->content, '.');
+
+        $message2 = $asyncHelper->get('get_test', true);
+        self::assertNull($message2);
+
+        $channel->publish('..', [], '', 'get_test');
+
+        $asyncHelper->get('get_test');
+        $client->disconnect();
+
+        await(sleep(5));
+
+        $client->connect();
+
+        $channel  = $client->channel();
+        $message3 = $asyncHelper->get('get_test');
+        self::assertNotNull($message3);
+        self::assertInstanceOf(Message::class, $message3);
+        self::assertEquals($message3->exchange, '');
+        self::assertEquals($message3->content, '..');
+
+        $channel->ack($message3);
+
+        $client->disconnect();
+
+        await(sleep(5));
+
+        self::assertFalse($client->isConnected());
+    }
+
+    public function testIterate(): void
+    {
+        self::expectOutputString('scscscsc');
+        $message = 'hi';
+        $asyncHelper = Helper::async(Configuration::fromDSN(Environment::getTestRabbitMqConnectionUri()));
+        $c = $this->helper->createClient();
+        $expectedMessages = [];
+        $messages = [];
+
+        $ch = $c->connect()->channel();
+        self::assertTrue($c->isConnected());
+        $ch->queueDeclare('test_queue', false, false, false, true);
+        self::assertTrue($c->isConnected());
+
+        Loop::futureTick(async(static function () use ($ch, &$expectedMessages, $message): void {
+            for ($i = 0; $i <= 1337; $i++) {
+                $expectedMessages[$i] = $message;
+                $ch->publish($message, [], '', 'test_queue');
+            }
+        }));
+
+        Loop::futureTick(async(static function () use ($asyncHelper, &$message): void {
+            $count = 0;
+            foreach ($asyncHelper->iterate('test_queue') as $message) {
+                $count++;
+                $messages[$count] = $message->content;
+
+                if ($count === 1337) {
+                    break;
+                }
+            }
+        }));
+
+        self::assertSame($expectedMessages, $messages);
+
+        await(sleep(0.1));
+        self::assertTrue($c->isConnected());
+        $c->disconnect();
+        self::assertFalse($c->isConnected());
+    }
+}

--- a/test/Helper/SyncTest.php
+++ b/test/Helper/SyncTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bunny\Test\Helper;
+
+use Bunny\Channel;
+use Bunny\Client;
+use Bunny\Configuration;
+use Bunny\Helper;
+use Bunny\Message;
+use Bunny\Test\Library\ClientHelper;
+use Bunny\Test\Library\Environment;
+use PHPUnit\Framework\TestCase;
+use React\Promise\Deferred;
+use WyriHaximus\React\PHPUnit\RunTestsInFibersTrait;
+use function React\Async\await;
+
+class SyncTest extends TestCase
+{
+    use RunTestsInFibersTrait;
+
+    private ClientHelper $helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->helper = new ClientHelper();
+    }
+
+    public function testPublish(): void
+    {
+        /**
+         * @var Deferred<string> $deferred
+         */
+        $deferred = new Deferred();
+        $c = $this->helper->createClient();
+        $a = Helper::sync(Configuration::fromDSN(Environment::getTestRabbitMqConnectionUri()));
+
+        $ch = $c->connect()->channel();
+        self::assertTrue($c->isConnected());
+        $ch->queueDeclare('test_queue', false, false, false, true);
+        self::assertTrue($c->isConnected());
+        $ch->consume(static function (Message $msg, Channel $ch, Client $c) use ($deferred): void {
+            $deferred->resolve($msg->content);
+        });
+        self::assertTrue($c->isConnected());
+        $a->publish('hi', [], '', 'test_queue');
+        self::assertEquals('hi', await($deferred->promise()));
+
+        self::assertTrue($c->isConnected());
+        $c->disconnect();
+        self::assertFalse($c->isConnected());
+    }
+}


### PR DESCRIPTION
Introduce (async) helpers for quick operations where full control isn't required and one off calls are what are needed 80% of the time.

- [ ] Publish (async)
- [ ] Publish (sync)
- [ ] Get (async)
- [ ] Get (sync)
- [ ] Consume(async)
- [ ] Consume(sync)