### PR TITLE
[0.6.x] Optional loop instance to client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "ext-pcntl": "*",
-        "doctrine/coding-standard": "^12.0",
+        "doctrine/coding-standard": "^13.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.6",
         "react/child-process": "^0.6.5",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,6 +27,8 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.AssignmentInCondition.AssignmentInCondition"/>
         <exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat.DisallowedShortNullable"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
     </rule>
     <rule ref="Generic.Formatting.SpaceAfterNot">

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use Bunny\Protocol\MethodConnectionStartFrame;
 use Bunny\Protocol\ProtocolReader;
 use Bunny\Protocol\ProtocolWriter;
 use InvalidArgumentException;
+use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Socket\Connector;
 use Throwable;
@@ -70,7 +71,7 @@ class Client implements ClientInterface
     /**
      * @param Configuration|array<string, mixed> $configuration
      */
-    public function __construct(Configuration|array $configuration = [])
+    public function __construct(Configuration|array $configuration = [], ?LoopInterface $loop = null)
     {
         if (is_array($configuration)) {
             if (!isset($configuration['host'])) {
@@ -155,7 +156,7 @@ class Client implements ClientInterface
         $this->connector = new Connector([
             'timeout' => $this->configuration->timeout,
             'tls' => $this->configuration->tls,
-        ]);
+        ], $loop);
 
         $this->state = ClientState::NotConnected;
         $this->channels = new Channels();

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,9 +10,9 @@ use Bunny\Protocol\MethodConnectionStartFrame;
 use Bunny\Protocol\ProtocolReader;
 use Bunny\Protocol\ProtocolWriter;
 use InvalidArgumentException;
-use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Socket\Connector;
+use React\Socket\ConnectorInterface;
 use Throwable;
 use function React\Async\async;
 use function React\Async\await;
@@ -49,7 +49,7 @@ class Client implements ClientInterface
 {
     private readonly Configuration $configuration;
 
-    private readonly Connector $connector;
+    private readonly ConnectorInterface $connector;
 
     private ClientState $state = ClientState::NotConnected;
 
@@ -71,7 +71,7 @@ class Client implements ClientInterface
     /**
      * @param Configuration|array<string, mixed> $configuration
      */
-    public function __construct(Configuration|array $configuration = [], ?LoopInterface $loop = null)
+    public function __construct(Configuration|array $configuration = [], ?ConnectorInterface $connector = null)
     {
         if (is_array($configuration)) {
             if (!isset($configuration['host'])) {
@@ -153,10 +153,10 @@ class Client implements ClientInterface
         }
 
         $this->configuration = $configuration;
-        $this->connector = new Connector([
+        $this->connector = $connector ?? new Connector([
             'timeout' => $this->configuration->timeout,
             'tls' => $this->configuration->tls,
-        ], $loop);
+        ]);
 
         $this->state = ClientState::NotConnected;
         $this->channels = new Channels();


### PR DESCRIPTION
Make possible to set custom `LoopInterface` instance into newly created `Client`.