### PR TITLE
[0.6.x] CI Optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,31 @@ jobs:
     name: Supported Versions Matrix
     runs-on: ubuntu-latest
     outputs:
+      extensions: ${{ steps.supported-versions-matrix.outputs.extensions }}
+      highest: ${{ steps.supported-versions-matrix.outputs.highest }}
+      lowest: ${{ steps.supported-versions-matrix.outputs.lowest }}
       version: ${{ steps.supported-versions-matrix.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: supported-versions-matrix
         uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
   static-anylsis:
-    name: "Run static analysis"
+    name: "Run static analysis on PHP ${{ matrix.php }}"
     runs-on: ubuntu-latest
+    needs:
+      - supported-versions-matrix
     strategy:
-      fail-fast: true
+      fail-fast: false
+      matrix:
+        php: ${{ fromJson(format('["{0}","{1}"]"', needs.supported-versions-matrix.outputs.lowest, needs.supported-versions-matrix.outputs.highest)) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
-          extensions: mbstring, ctype, iconv, bcmath, filter, json
+          php-version: ${{ matrix.php }}
+          extensions: ${{ join(fromJson(needs.supported-versions-matrix.outputs.extensions), ',') }}
           tools: composer
       - name: Install Dependencies
         uses: ramsey/composer-install@v2
@@ -46,16 +53,16 @@ jobs:
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
         composer: [lowest, locked, highest]
-        rabbitmq: ["3", "3.9", "4"]
+        rabbitmq: ["3", "3.8", "3.9", "4", "4.1"]
         ssl_test: ["no", "yes", "client"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, ctype, iconv, bcmath, filter, json
+          extensions: ${{ join(fromJson(needs.supported-versions-matrix.outputs.extensions), ',') }}
           tools: composer
       - name: Install Dependencies
         uses: ramsey/composer-install@v2


### PR DESCRIPTION
* Get PHP extensions through action
* Add 3.8 and 4.1 RabbitMQ to test against
* Update actions/checkout
* Run PHPStan on the highest and lowest PHP version supported in range