### PR TITLE
Drop react-amqp from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ You might ask if there isn't a library/extension to connect to AMQP broker (e.g.
 
 - [ext-amqp](http://pecl.php.net/package/amqp) - PHP extension
 - [php-amqplib](https://github.com/php-amqplib/php-amqplib) - pure-PHP AMQP protocol implementation
-- [react-amqp](https://github.com/JCook21/ReactAMQP) - ext-amqp binding to ReactPHP
 
 Why should you want to choose BunnyPHP instead?
 


### PR DESCRIPTION
It's achieved two years ago and hasn't been updated in ~120 years