### PR TITLE
[0.6.x] Make it abundantly clear Bunny must run in a fiber

### DIFF
--- a/benchmark/consumer.php
+++ b/benchmark/consumer.php
@@ -2,34 +2,36 @@
 
 declare(strict_types=1);
 
-namespace Bunny;
-
-use function getmypid;
-use function microtime;
-use function printf;
+use Bunny\Channel;
+use Bunny\Client;
+use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$c = new Client();
-$ch = $c->connect()->channel();
+$client = new Client();
+Loop::futureTick(async(static function () use ($client): void {
+    $channel = $client->channel();
 
-$ch->queueDeclare('bench_queue');
-$ch->exchangeDeclare('bench_exchange');
-$ch->queueBind('bench_exchange', 'bench_queue');
+    $channel->queueDeclare('bench_queue');
+    $channel->exchangeDeclare('bench_exchange');
+    $channel->queueBind('bench_exchange', 'bench_queue');
 
-$time = null;
-$count = 0;
+    $time = null;
+    $count = 0;
 
-$ch->consume(static function (Message $msg, Channel $ch, Client $c) use (&$time, &$count): void {
-    if ($time === null) {
-        $time = microtime(true);
-    }
+    $channel->consume(static function (Message $msg, Channel $channel, Client $c) use (&$time, &$count): void {
+        if ($time === null) {
+            $time = microtime(true);
+        }
 
-    if ($msg->content === 'quit') {
-        $runTime = microtime(true) - $time;
-        printf("Consume: Pid: %s, Count: %s, Time: %.6f, Msg/sec: %.0f\n", getmypid(), $count, $runTime, 1 / $runTime * $count);
-        $c->disconnect();
-    } else {
-        ++$count;
-    }
-}, 'bench_queue', '', false, true);
+        if ($msg->content === 'quit') {
+            $runTime = microtime(true) - $time;
+            printf("Consume: Pid: %s, Count: %s, Time: %.6f, Msg/sec: %.0f\n", getmypid(), $count, $runTime, 1 / $runTime * $count);
+            $c->disconnect();
+        } else {
+            ++$count;
+        }
+    }, 'bench_queue', '', false, true);
+}));

--- a/benchmark/producer.php
+++ b/benchmark/producer.php
@@ -2,45 +2,44 @@
 
 declare(strict_types=1);
 
-namespace Bunny;
-
-use function getmypid;
-use function microtime;
-use function printf;
+use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$c = new Client();
-$c->connect();
-$ch = $c->channel();
+$client = new Client();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$ch->queueDeclare('bench_queue');
-$ch->exchangeDeclare('bench_exchange');
-$ch->queueBind('bench_exchange', 'bench_queue');
+    $channel->queueDeclare('bench_queue');
+    $channel->exchangeDeclare('bench_exchange');
+    $channel->queueBind('bench_exchange', 'bench_queue');
 
-$body = <<<'EOT'
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza
-EOT;
+    $body = <<<'EOT'
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+    abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza
+    EOT;
 
-$time = microtime(true);
-$max = isset($argv[1]) ? (int) $argv[1] : 1;
+    $time = microtime(true);
+    $max = isset($argv[1]) ? (int) $argv[1] : 1;
 
-for ($i = 0; $i < $max; $i++) {
-    $ch->publish($body, [], 'bench_exchange');
-}
+    for ($i = 0; $i < $max; $i++) {
+        $channel->publish($body, [], 'bench_exchange');
+    }
 
-$runTime = microtime(true) - $time;
-printf("Produce: Pid: %s, Time: %.6f, Msg/sec: %.0f\n", getmypid(), $runTime, 1 / $runTime * $max);
+    $runTime = microtime(true) - $time;
+    printf("Produce: Pid: %s, Time: %.6f, Msg/sec: %.0f\n", getmypid(), $runTime, 1 / $runTime * $max);
 
-$ch->publish('quit', [], 'bench_exchange');
+    $channel->publish('quit', [], 'bench_exchange');
 
-$c->disconnect();
+    $client->disconnect();
+}));

--- a/examples/worker.php
+++ b/examples/worker.php
@@ -14,22 +14,22 @@ $channel = null;
 $consumerTag = null;
 
 // Capture signals - SIGINT = Ctrl+C; SIGTERM = `kill`
-Loop::addSignal(SIGINT, static function (int $signal) use (&$channel, &$consumerTag): void {
+Loop::addSignal(SIGINT, async(static function (int $signal) use (&$channel, &$consumerTag): void {
     print 'Consumer cancelled\n';
     $channel->cancel($consumerTag);
 
     Loop::addTimer(3, static function (): void {
         Loop::stop();
     });
-});
-Loop::addSignal(SIGTERM, static function (int $signal) use (&$channel, &$consumerTag): void {
+}));
+Loop::addSignal(SIGTERM, async(static function (int $signal) use (&$channel, &$consumerTag): void {
     print 'Consumer cancelled\n';
     $channel->cancel($consumerTag);
 
     Loop::addTimer(3, static function (): void {
         Loop::stop();
     });
-});
+}));
 
 $clientConfig = [
     'host' => 'rabbitmq.example.com',

--- a/tutorial/1-hello-world/receive.php
+++ b/tutorial/1-hello-world/receive.php
@@ -5,22 +5,26 @@ declare(strict_types=1);
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($client): void {
+    $channel = $client->channel();
 
-$channel->queueDeclare('hello', false, false, false, false);
+    $channel->queueDeclare('hello', false, false, false, false);
 
-echo ' [*] Waiting for messages. To exit press CTRL+C', PHP_EOL;
+    echo ' [*] Waiting for messages. To exit press CTRL+C', PHP_EOL;
 
-$channel->consume(
-    static function (Message $message, Channel $channel): void {
-        echo ' [x] Received ' . $message->content . PHP_EOL;
-    },
-    'hello',
-    '',
-    false,
-    true,
-);
+    $channel->consume(
+        static function (Message $message, Channel $channel): void {
+            echo ' [x] Received ' . $message->content . PHP_EOL;
+        },
+        'hello',
+        '',
+        false,
+        true,
+    );
+}));

--- a/tutorial/1-hello-world/send.php
+++ b/tutorial/1-hello-world/send.php
@@ -3,15 +3,19 @@
 declare(strict_types=1);
 
 use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
-$channel->queueDeclare('hello', false, false, false, false);
+Loop::futureTick(async(static function () use ($client): void {
+    $channel = $client->channel();
+    $channel->queueDeclare('hello', false, false, false, false);
 
-$channel->publish('Hello World!', [], '', 'hello');
-echo ' [x] Sent "Hello World!"' . PHP_EOL;
+    $channel->publish('Hello World!', [], '', 'hello');
+    echo ' [x] Sent "Hello World!"' . PHP_EOL;
 
-$channel->close();
-$client->disconnect();
+    $channel->close();
+    $client->disconnect();
+}));

--- a/tutorial/2-work-queues/new_task.php
+++ b/tutorial/2-work-queues/new_task.php
@@ -3,22 +3,26 @@
 declare(strict_types=1);
 
 use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->queueDeclare('task_queue', false, true, false, false);
+    $channel->queueDeclare('task_queue', false, true, false, false);
 
-$data = implode(' ', array_slice($argv, 1));
-$channel->publish(
-    $data,
-    ['delivery-mode' => 2],
-    '',
-    'task_queue',
-);
-echo ' [x] Sent "' . $data . '"' . PHP_EOL;
+    $data = implode(' ', array_slice($argv, 1));
+    $channel->publish(
+        $data,
+        ['delivery-mode' => 2],
+        '',
+        'task_queue',
+    );
+    echo ' [x] Sent "' . $data . '"' . PHP_EOL;
 
-$channel->close();
-$client->disconnect();
+    $channel->close();
+    $client->disconnect();
+}));

--- a/tutorial/2-work-queues/worker.php
+++ b/tutorial/2-work-queues/worker.php
@@ -5,23 +5,27 @@ declare(strict_types=1);
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($client): void {
+    $channel = $client->channel();
 
-$channel->queueDeclare('task_queue', false, true, false, false);
+    $channel->queueDeclare('task_queue', false, true, false, false);
 
-echo ' [*] Waiting for messages. To exit press CTRL+C', "\n";
+    echo ' [*] Waiting for messages. To exit press CTRL+C', "\n";
 
-$channel->qos(0, 1);
-$channel->consume(
-    static function (Message $message, Channel $channel, Client $client): void {
-        echo ' [x] Received ' . $message->content . PHP_EOL;
-        sleep(substr_count($message->content, '.'));
-        echo ' [x] Done' . PHP_EOL;
-        $channel->ack($message);
-    },
-    'task_queue',
-);
+    $channel->qos(0, 1);
+    $channel->consume(
+        async(static function (Message $message, Channel $channel, Client $client): void {
+            echo ' [x] Received ' . $message->content . PHP_EOL;
+            sleep(substr_count($message->content, '.'));
+            echo ' [x] Done' . PHP_EOL;
+            $channel->ack($message);
+        }),
+        'task_queue',
+    );
+}));

--- a/tutorial/3-publish-subscribe/emit_log.php
+++ b/tutorial/3-publish-subscribe/emit_log.php
@@ -3,17 +3,21 @@
 declare(strict_types=1);
 
 use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('logs', 'fanout');
+    $channel->exchangeDeclare('logs', 'fanout');
 
-$data = implode(' ', array_slice($argv, 1));
-$channel->publish($data, [], 'logs');
-echo ' [x] Sent "' . $data . '"' . PHP_EOL;
+    $data = implode(' ', array_slice($argv, 1));
+    $channel->publish($data, [], 'logs');
+    echo ' [x] Sent "' . $data . '"' . PHP_EOL;
 
-$channel->close();
-$client->disconnect();
+    $channel->close();
+    $client->disconnect();
+}));

--- a/tutorial/3-publish-subscribe/receive_logs.php
+++ b/tutorial/3-publish-subscribe/receive_logs.php
@@ -5,24 +5,28 @@ declare(strict_types=1);
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('logs', 'fanout');
-$queue = $channel->queueDeclare('', false, false, true, false);
-$channel->queueBind('logs', $queue->queue);
+    $channel->exchangeDeclare('logs', 'fanout');
+    $queue = $channel->queueDeclare('', false, false, true, false);
+    $channel->queueBind('logs', $queue->queue);
 
-echo ' [*] Waiting for logs. To exit press CTRL+C' . PHP_EOL;
+    echo ' [*] Waiting for logs. To exit press CTRL+C' . PHP_EOL;
 
-$channel->consume(
-    static function (Message $message, Channel $channel, Client $client): void {
-        echo ' [x] ' . $message->content . PHP_EOL;
-    },
-    $queue->queue,
-    '',
-    false,
-    true,
-);
+    $channel->consume(
+        static function (Message $message, Channel $channel, Client $client): void {
+            echo ' [x] ' . $message->content . PHP_EOL;
+        },
+        $queue->queue,
+        '',
+        false,
+        true,
+    );
+}));

--- a/tutorial/4-routing/emit_log.php
+++ b/tutorial/4-routing/emit_log.php
@@ -3,22 +3,26 @@
 declare(strict_types=1);
 
 use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('direct_logs', 'direct');
+    $channel->exchangeDeclare('direct_logs', 'direct');
 
-$severity = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : 'info';
-$data = implode(' ', array_slice($argv, 2));
-if (empty($data)) {
-    $data = 'Hello World!';
-}
+    $severity = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : 'info';
+    $data = implode(' ', array_slice($argv, 2));
+    if (empty($data)) {
+        $data = 'Hello World!';
+    }
 
-$channel->publish($data, [], 'direct_logs', $severity);
-echo ' [x] Sent ' . $severity . ':' . $data . PHP_EOL;
+    $channel->publish($data, [], 'direct_logs', $severity);
+    echo ' [x] Sent ' . $severity . ':' . $data . PHP_EOL;
 
-$channel->close();
-$client->disconnect();
+    $channel->close();
+    $client->disconnect();
+}));

--- a/tutorial/4-routing/receive_logs.php
+++ b/tutorial/4-routing/receive_logs.php
@@ -5,34 +5,38 @@ declare(strict_types=1);
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('direct_logs', 'direct');
-$queue = $channel->queueDeclare('', false, false, true, false);
+    $channel->exchangeDeclare('direct_logs', 'direct');
+    $queue = $channel->queueDeclare('', false, false, true, false);
 
-$severities = array_slice($argv, 1);
-if (empty($severities)) {
-    file_put_contents('php://stderr', sprintf("Usage: %s [info] [warning] [error]\n", $argv[0]));
-    $client->disconnect();
-    exit(1);
-}
+    $severities = array_slice($argv, 1);
+    if (empty($severities)) {
+        file_put_contents('php://stderr', sprintf("Usage: %s [info] [warning] [error]\n", $argv[0]));
+        $client->disconnect();
+        exit(1);
+    }
 
-foreach ($severities as $severity) {
-    $channel->queueBind('direct_logs', $queue->queue, $severity);
-}
+    foreach ($severities as $severity) {
+        $channel->queueBind('direct_logs', $queue->queue, $severity);
+    }
 
-echo ' [*] Waiting for logs. To exit press CTRL+C' . PHP_EOL;
+    echo ' [*] Waiting for logs. To exit press CTRL+C' . PHP_EOL;
 
-$channel->consume(
-    static function (Message $message, Channel $channel, Client $client): void {
-        echo ' [x] ', $message->routingKey, ':', $message->content, "\n";
-    },
-    $queue->queue,
-    '',
-    false,
-    true,
-);
+    $channel->consume(
+        static function (Message $message, Channel $channel, Client $client): void {
+            echo ' [x] ', $message->routingKey, ':', $message->content, "\n";
+        },
+        $queue->queue,
+        '',
+        false,
+        true,
+    );
+}));

--- a/tutorial/5-topics/emit_log_topic.php
+++ b/tutorial/5-topics/emit_log_topic.php
@@ -3,22 +3,26 @@
 declare(strict_types=1);
 
 use Bunny\Client;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('topic_logs', 'topic');
+    $channel->exchangeDeclare('topic_logs', 'topic');
 
-$routingKey = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : 'info';
-$data = implode(' ', array_slice($argv, 2));
-if (empty($data)) {
-    $data = 'Hello World!';
-}
+    $routingKey = isset($argv[1]) && !empty($argv[1]) ? $argv[1] : 'info';
+    $data = implode(' ', array_slice($argv, 2));
+    if (empty($data)) {
+        $data = 'Hello World!';
+    }
 
-$channel->publish($data, [], 'topic_logs', $routingKey);
-echo ' [x] Sent ' . $routingKey . ':' . $data . PHP_EOL;
+    $channel->publish($data, [], 'topic_logs', $routingKey);
+    echo ' [x] Sent ' . $routingKey . ':' . $data . PHP_EOL;
 
-$channel->close();
-$client->disconnect();
+    $channel->close();
+    $client->disconnect();
+}));

--- a/tutorial/5-topics/receive_logs_topic.php
+++ b/tutorial/5-topics/receive_logs_topic.php
@@ -5,34 +5,38 @@ declare(strict_types=1);
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use React\EventLoop\Loop;
+use function React\Async\async;
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $client = new Client();
-$channel = $client->channel();
+Loop::futureTick(async(static function () use ($argv, $client): void {
+    $channel = $client->channel();
 
-$channel->exchangeDeclare('topic_logs', 'topic');
-$queue = $channel->queueDeclare('', false, false, true, false);
+    $channel->exchangeDeclare('topic_logs', 'topic');
+    $queue = $channel->queueDeclare('', false, false, true, false);
 
-$bindingKeys = array_slice($argv, 1);
-if (empty($bindingKeys)) {
-    file_put_contents('php://stderr', sprintf("Usage: %s [binding_key]\n", $argv[0]));
-    $client->disconnect();
-    exit(1);
-}
+    $bindingKeys = array_slice($argv, 1);
+    if (empty($bindingKeys)) {
+        file_put_contents('php://stderr', sprintf("Usage: %s [binding_key]\n", $argv[0]));
+        $client->disconnect();
+        exit(1);
+    }
 
-foreach ($bindingKeys as $bindingKey) {
-    $channel->queueBind('topic_logs', $queue->queue, $bindingKey);
-}
+    foreach ($bindingKeys as $bindingKey) {
+        $channel->queueBind('topic_logs', $queue->queue, $bindingKey);
+    }
 
-echo ' [*] Waiting for logs. To exit press CTRL+C', "\n";
+    echo ' [*] Waiting for logs. To exit press CTRL+C', "\n";
 
-$channel->consume(
-    static function (Message $message, Channel $channel, Client $client): void {
-        echo ' [x] ' . $message->routingKey . ':' . $message->content . PHP_EOL;
-    },
-    $queue->queue,
-    '',
-    false,
-    true,
-);
+    $channel->consume(
+        static function (Message $message, Channel $channel, Client $client): void {
+            echo ' [x] ' . $message->routingKey . ':' . $message->content . PHP_EOL;
+        },
+        $queue->queue,
+        '',
+        false,
+        true,
+    );
+}));


### PR DESCRIPTION
- [X] Add fiber examples for all examples in the readme
- [x] Convert the benchmark to be encapsulated in fibers
- [x] Convert the tutorials to be encapsulated in fibers

@pulmer-cp @mdissington @andrew-demb @menturion @kostirez1 Since you either created or responded/emoted to some message in #192 or #191 I would love your feedback on this PR, addressing that in the documentation and examples. The changes in the readme start here: https://github.com/jakubkulhan/bunny/tree/0.6.x-make-it-abundantly-clear-Bunny-must-run-in-a-fiber?tab=readme-ov-file#always-run-moving-parts-in-a-fiber