### PR TITLE
[0.6.x] Test against upcoming releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - id: supported-versions-matrix
         uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
+        with:
+          upcomingReleases: true
   static-anylsis:
     name: "Run static analysis on PHP ${{ matrix.php }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Realised after the PHP 8.5 release that Bunny 0.6 (and 0.5 for that matter) tests never ran against PHP 8.5. This flag will at some point in the pre-release cycle start testing against them.