### PR TITLE
Fix error handling, channel closing and connection loss

### DIFF
--- a/src/Channel.php
+++ b/src/Channel.php
@@ -111,6 +111,18 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
     public function getClient(): Connection
     {
+        if ($this->state === ChannelState::Error) {
+            throw new ChannelException('Channel in error state.');
+        }
+
+        if ($this->state === ChannelState::Closing) {
+            throw new ChannelException('Channel is closing');
+        }
+
+        if ($this->state === ChannelState::Closed) {
+            throw new ChannelException('Channel is closed');
+        }
+
         return $this->connection;
     }
 
@@ -197,7 +209,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
      *
      * Always returns a promise, because there can be outstanding messages to be processed.
      */
-    public function close(int $replyCode = 0, string $replyText = ''): void
+    public function close(int $replyCode = 0, string $replyText = '', bool $byServer = false): void
     {
         if ($this->state === ChannelState::Closed) {
             throw new ChannelException(sprintf('Trying to close already closed channel #%d.', $this->channelId));
@@ -209,13 +221,16 @@ class Channel implements ChannelInterface, EventEmitterInterface
             return;
         }
 
+        if($byServer) {
+            $this->onClose();
+            return;
+        }
+
         $this->state = ChannelState::Closing;
 
         $this->connection->channelClose($this->channelId, $replyCode, 0, 0, $replyText);
         $this->closeDeferred = new Deferred();
-        $this->closePromise = $this->closeDeferred->promise()->then(function (): void {
-            $this->emit('close');
-        });
+        $this->closePromise = $this->closeDeferred->promise();
 
         await($this->closePromise);
     }
@@ -301,7 +316,7 @@ class Channel implements ChannelInterface, EventEmitterInterface
 
                 if ($this->bodySizeRemaining < 0) {
                     $this->state = ChannelState::Error;
-                    $this->connection->disconnect(Constants::STATUS_SYNTAX_ERROR, $errorMessage = 'Body overflow, received ' . (-$this->bodySizeRemaining) . ' more bytes.');
+                    $this->client->disconnect(Constants::STATUS_SYNTAX_ERROR, $errorMessage = 'Body overflow, received ' . (-$this->bodySizeRemaining) . ' more bytes.');
 
                     throw new ChannelException($errorMessage);
                 }
@@ -426,142 +441,157 @@ class Channel implements ChannelInterface, EventEmitterInterface
      */
     public function onFrameReceived(AbstractFrame $frame): void
     {
-        if ($this->state === ChannelState::Error) {
-            throw new ChannelException('Channel in error state.');
-        }
-
-        if ($this->state === ChannelState::Closed) {
-            throw new ChannelException(sprintf('Received frame #%d on closed channel #%d.', $frame->type, $this->channelId));
-        }
-
-        if ($frame instanceof MethodFrame) {
-            if ($this->state === ChannelState::Closing && !($frame instanceof MethodChannelCloseOkFrame)) {
-                // drop frames in closing state
-                return;
+        try {
+            if ($this->state === ChannelState::Error) {
+                throw new ChannelException('Channel in error state.');
             }
 
-            if ($this->state !== ChannelState::Ready && !($frame instanceof MethodChannelCloseOkFrame)) {
-                $currentState = $this->state;
-                $this->state = ChannelState::Error;
+            if ($this->state === ChannelState::Closed) {
+                throw new ChannelException(sprintf('Received frame #%d on closed channel #%d.', $frame->type, $this->channelId));
+            }
 
-                if ($currentState === ChannelState::AwaitingHeader) {
-                    $msg = 'Got method frame, expected header frame.';
-                } elseif ($currentState === ChannelState::AwaitingBody) {
-                    $msg = 'Got method frame, expected body frame.';
+            if ($frame instanceof MethodFrame) {
+                if ($this->state === ChannelState::Closing && !($frame instanceof MethodChannelCloseOkFrame)) {
+                    // drop frames in closing state
+                    return;
+                }
+
+                if ($this->state !== ChannelState::Ready && !($frame instanceof MethodChannelCloseOkFrame)) {
+                    $currentState = $this->state;
+                    $this->state = ChannelState::Error;
+
+                    if ($currentState === ChannelState::AwaitingHeader) {
+                        $msg = 'Got method frame, expected header frame.';
+                    } elseif ($currentState === ChannelState::AwaitingBody) {
+                        $msg = 'Got method frame, expected body frame.';
+                    } else {
+                        throw new LogicException('Unhandled channel state.');
+                    }
+
+                    $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
+
+                    throw new ChannelException('Unexpected frame: ' . $msg);
+                }
+
+                if ($frame instanceof MethodChannelCloseOkFrame) {
+                    $this->onClose();
+                } elseif ($frame instanceof MethodBasicReturnFrame) {
+                    $this->returnFrame = $frame;
+                    $this->state = ChannelState::AwaitingHeader;
+                } elseif ($frame instanceof MethodBasicDeliverFrame) {
+                    $this->deliverFrame = $frame;
+                    $this->state = ChannelState::AwaitingHeader;
+                } elseif ($frame instanceof MethodBasicAckFrame) {
+                    foreach ($this->ackCallbacks as $callback) {
+                        $callback($frame);
+                    }
+                } elseif ($frame instanceof MethodBasicNackFrame) {
+                    foreach ($this->ackCallbacks as $callback) {
+                        $callback($frame);
+                    }
+                } elseif($frame instanceof MethodChannelCloseFrame) {
+                    $this->onClose();
+                    throw new ChannelException('Channel closed by server: ' . $frame->replyText, $frame->replyCode);
                 } else {
-                    throw new LogicException('Unhandled channel state.');
+                    throw new ChannelException('Unhandled method frame ' . $frame::class . '.');
+                }
+            } elseif ($frame instanceof ContentHeaderFrame) {
+                if ($this->state === ChannelState::Closing) {
+                    // drop frames in closing state
+                    return;
                 }
 
-                $this->connection->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
+                if ($this->state !== ChannelState::AwaitingHeader) {
+                    $currentState = $this->state;
+                    $this->state = ChannelState::Error;
 
-                throw new ChannelException('Unexpected frame: ' . $msg);
-            }
+                    if ($currentState === ChannelState::Ready) {
+                        $msg = 'Got header frame, expected method frame.';
+                    } elseif ($currentState === ChannelState::AwaitingBody) {
+                        $msg = 'Got header frame, expected content frame.';
+                    } else {
+                        throw new LogicException('Unhandled channel state.');
+                    }
 
-            if ($frame instanceof MethodChannelCloseOkFrame) {
-                $this->state = ChannelState::Closed;
+                    $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
 
-                if ($this->closeDeferred !== null) {
-                    $this->closeDeferred->resolve($this->channelId);
+                    throw new ChannelException('Unexpected frame: ' . $msg);
                 }
 
-//                // break reference cycle, must be called after resolving promise
-//                $this->client = null;
-                // break consumers' reference cycle
-                $this->consumeConcurrency = [];
-                $this->consumeConcurrent = [];
-                $this->deliverCallbacks = [];
-                $this->deliveryQueue = [];
-            } elseif ($frame instanceof MethodBasicReturnFrame) {
-                $this->returnFrame = $frame;
-                $this->state = ChannelState::AwaitingHeader;
-            } elseif ($frame instanceof MethodBasicDeliverFrame) {
-                $this->deliverFrame = $frame;
-                $this->state = ChannelState::AwaitingHeader;
-            } elseif ($frame instanceof MethodBasicAckFrame) {
-                foreach ($this->ackCallbacks as $callback) {
-                    $callback($frame);
+                $this->headerFrame = $frame;
+                $this->bodySizeRemaining = $frame->bodySize;
+
+                if ($this->bodySizeRemaining > 0) {
+                    $this->state = ChannelState::AwaitingBody;
+                } else {
+                    $this->state = ChannelState::Ready;
+                    $this->onBodyComplete();
                 }
-            } elseif ($frame instanceof MethodBasicNackFrame) {
-                foreach ($this->ackCallbacks as $callback) {
-                    $callback($frame);
+            } elseif ($frame instanceof ContentBodyFrame) {
+                if ($this->state === ChannelState::Closing) {
+                    // drop frames in closing state
+                    return;
                 }
-            } elseif ($frame instanceof MethodChannelCloseFrame) {
-                throw new ChannelException('Channel closed by server: ' . $frame->replyText, $frame->replyCode);
+
+                if ($this->state !== ChannelState::AwaitingBody) {
+                    $currentState = $this->state;
+                    $this->state = ChannelState::Error;
+
+                    if ($currentState === ChannelState::Ready) {
+                        $msg = 'Got body frame, expected method frame.';
+                    } elseif ($currentState === ChannelState::AwaitingHeader) {
+                        $msg = 'Got body frame, expected header frame.';
+                    } else {
+                        throw new LogicException('Unhandled channel state.');
+                    }
+
+                    $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
+
+                    throw new ChannelException('Unexpected frame: ' . $msg);
+                }
+
+                $this->bodyBuffer->append($frame->payload);
+                $this->bodySizeRemaining -= $frame->payloadSize;
+
+                if ($this->bodySizeRemaining < 0) {
+                    $this->state = ChannelState::Error;
+                    $this->client->disconnect(Constants::STATUS_SYNTAX_ERROR, 'Body overflow, received ' . (-$this->bodySizeRemaining) . ' more bytes.');
+                } elseif ($this->bodySizeRemaining === 0) {
+                    $this->state = ChannelState::Ready;
+                    $this->onBodyComplete();
+                }
+            } elseif ($frame instanceof HeartbeatFrame) {
+                $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got heartbeat on non-zero channel.');
+
+                throw new ChannelException('Unexpected heartbeat frame.');
             } else {
-                throw new ChannelException('Unhandled method frame ' . $frame::class . '.');
+                throw new ChannelException('Unhandled frame ' . $frame::class . '.');
             }
-        } elseif ($frame instanceof ContentHeaderFrame) {
-            if ($this->state === ChannelState::Closing) {
-                // drop frames in closing state
-                return;
-            }
-
-            if ($this->state !== ChannelState::AwaitingHeader) {
-                $currentState = $this->state;
-                $this->state = ChannelState::Error;
-
-                if ($currentState === ChannelState::Ready) {
-                    $msg = 'Got header frame, expected method frame.';
-                } elseif ($currentState === ChannelState::AwaitingBody) {
-                    $msg = 'Got header frame, expected content frame.';
-                } else {
-                    throw new LogicException('Unhandled channel state.');
-                }
-
-                $this->connection->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
-
-                throw new ChannelException('Unexpected frame: ' . $msg);
-            }
-
-            $this->headerFrame = $frame;
-            $this->bodySizeRemaining = $frame->bodySize;
-
-            if ($this->bodySizeRemaining > 0) {
-                $this->state = ChannelState::AwaitingBody;
-            } else {
-                $this->state = ChannelState::Ready;
-                $this->onBodyComplete();
-            }
-        } elseif ($frame instanceof ContentBodyFrame) {
-            if ($this->state === ChannelState::Closing) {
-                // drop frames in closing state
-                return;
-            }
-
-            if ($this->state !== ChannelState::AwaitingBody) {
-                $currentState = $this->state;
-                $this->state = ChannelState::Error;
-
-                if ($currentState === ChannelState::Ready) {
-                    $msg = 'Got body frame, expected method frame.';
-                } elseif ($currentState === ChannelState::AwaitingHeader) {
-                    $msg = 'Got body frame, expected header frame.';
-                } else {
-                    throw new LogicException('Unhandled channel state.');
-                }
-
-                $this->connection->disconnect(Constants::STATUS_UNEXPECTED_FRAME, $msg);
-
-                throw new ChannelException('Unexpected frame: ' . $msg);
-            }
-
-            $this->bodyBuffer->append($frame->payload);
-            $this->bodySizeRemaining -= $frame->payloadSize;
-
-            if ($this->bodySizeRemaining < 0) {
-                $this->state = ChannelState::Error;
-                $this->connection->disconnect(Constants::STATUS_SYNTAX_ERROR, 'Body overflow, received ' . (-$this->bodySizeRemaining) . ' more bytes.');
-            } elseif ($this->bodySizeRemaining === 0) {
-                $this->state = ChannelState::Ready;
-                $this->onBodyComplete();
-            }
-        } elseif ($frame instanceof HeartbeatFrame) {
-            $this->connection->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got heartbeat on non-zero channel.');
-
-            throw new ChannelException('Unexpected heartbeat frame.');
-        } else {
-            throw new ChannelException('Unhandled frame ' . $frame::class . '.');
+        } catch(\Throwable $e) {
+            $this -> emit('error', [$e]);
         }
+    }
+
+    /**
+     * Callback after channel has been closed.
+     */
+    private function onClose(): void
+    {
+        $this->state = ChannelState::Closed;
+
+        if ($this->closeDeferred !== null) {
+            $this->closeDeferred->resolve($this->channelId);
+        }
+
+        // break reference cycle, must be called after resolving promise
+        // $this->client = null;
+        // break consumers' reference cycle
+        $this->consumeConcurrency = [];
+        $this->consumeConcurrent = [];
+        $this->deliverCallbacks = [];
+        $this->deliveryQueue = [];
+
+        $this->emit('close');
     }
 
     /**

--- a/src/ChannelInterface.php
+++ b/src/ChannelInterface.php
@@ -71,7 +71,7 @@ interface ChannelInterface
      *
      * Always returns a promise, because there can be outstanding messages to be processed.
      */
-    public function close(int $replyCode = 0, string $replyText = ''): void;
+    public function close(int $replyCode = 0, string $replyText = '', bool $byServer = false): void;
 
     /**
      * Creates new consumer on channel.

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,8 @@ use Bunny\Protocol\Buffer;
 use Bunny\Protocol\MethodConnectionStartFrame;
 use Bunny\Protocol\ProtocolReader;
 use Bunny\Protocol\ProtocolWriter;
+use Evenement\EventEmitterInterface;
+use Evenement\EventEmitterTrait;
 use InvalidArgumentException;
 use React\Promise\Deferred;
 use Throwable;
@@ -42,8 +44,10 @@ use function strpos;
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  * @final Will be marked final in a future major release
  */
-class Client implements ClientInterface
+class Client implements ClientInterface, EventEmitterInterface
 {
+    use EventEmitterTrait;
+
     private readonly Configuration $configuration;
 
     private ClientState $state = ClientState::NotConnected;
@@ -275,7 +279,7 @@ class Client implements ClientInterface
     /**
      * Disconnects the client.
      */
-    public function disconnect(int $replyCode = 0, string $replyText = ''): void
+    public function disconnect(int $replyCode = 0, string $replyText = '', bool $byServer = false): void
     {
         if ($this->state === ClientState::Disconnecting) {
             return;
@@ -287,16 +291,18 @@ class Client implements ClientInterface
 
         $this->state = ClientState::Disconnecting;
 
+        $this -> emit('close');
+
         $promises = [];
         foreach ($this->channels->all() as $channelId => $channel) {
-            $promises[] = async(static function () use ($channel, $replyCode, $replyText): void {
-                $channel->close($replyCode, $replyText);
+            $promises[] = async(static function () use ($channel, $replyCode, $replyText, $byServer): void {
+                $channel->close($replyCode, $replyText, $byServer);
             })();
         }
 
         await(all($promises));
 
-        $this->connection->disconnect($replyCode, $replyText);
+        $this->connection->disconnect($replyCode, $replyText, $byServer);
 
         $this->state = ClientState::NotConnected;
     }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -8,7 +8,7 @@ interface ClientInterface
 {
     public function channel(): ChannelInterface;
 
-    public function disconnect(int $replyCode = 0, string $replyText = ''): void;
+    public function disconnect(int $replyCode = 0, string $replyText = '', bool $byServer = false): void;
 
     public function isConnected(): bool;
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -11,6 +11,7 @@ use Bunny\Protocol\ContentBodyFrame;
 use Bunny\Protocol\ContentHeaderFrame;
 use Bunny\Protocol\HeartbeatFrame;
 use Bunny\Protocol\MethodConnectionCloseFrame;
+use Bunny\Protocol\MethodChannelCloseFrame;
 use Bunny\Protocol\MethodFrame;
 use Bunny\Protocol\ProtocolReader;
 use Bunny\Protocol\ProtocolWriter;
@@ -59,40 +60,58 @@ final class Connection
         private readonly Channels $channels,
         private readonly Configuration $configuration,
     ) {
+        $this->connection->on('close', function(): void {
+            $this->client->disconnect(0, 'Connection lost', true);
+        });
         $this->connection->on('data', function (string $data): void {
             $this->readBuffer->append($data);
 
             while (($frame = $this->reader->consumeFrame($this->readBuffer)) !== null) {
                 $frameInAwaitList = false;
                 foreach ($this->awaitList as $index => $frameHandler) {
-                    if ($frameHandler['filter']($frame)) {
+                    $handled = null;
+                    $exception = null;
+                    try {
+                        $handled = $frameHandler['filter']($frame);
+                    } catch(\Throwable $e) {
+                        $exception = $e;
+                    }
+                    if ($exception || $handled) {
                         unset($this->awaitList[$index]);
-                        $frameHandler['promise']->resolve($frame);
+                        if($exception)
+                            $frameHandler['promise']->reject($exception);
+                        else
+                            $frameHandler['promise']->resolve($frame);
                         $frameInAwaitList = true;
                     }
                 }
 
-                if ($frameInAwaitList) {
+                if ($frameInAwaitList && ! $frame instanceof MethodConnectionCloseFrame && ! $frame instanceof MethodChannelCloseFrame) {
                     continue;
                 }
 
-                if ($frame->channel === 0) {
-                    $this->onFrameReceived($frame);
-                    continue;
-                }
+                try {
+                    if ($frame->channel === 0) {
+                        $this->onFrameReceived($frame);
+                        continue;
+                    }
 
-                if (!$this->channels->has($frame->channel)) {
-                    throw new ClientException(sprintf('Received frame #%d on closed channel #%d.', $frame->type, $frame->channel));
-                }
+                    if (!$this->channels->has($frame->channel)) {
+                        throw new ClientException(sprintf('Received frame #%d on closed channel #%d.', $frame->type, $frame->channel));
+                    }
 
-                $this->channels->get($frame->channel)->onFrameReceived($frame);
+                    $this->channels->get($frame->channel)->onFrameReceived($frame);
+                } catch(\Throwable $e) {
+                    $this -> client -> emit('error', [$e]);
+                }
             }
         });
     }
 
-    public function disconnect(int $code, string $reason): void
+    public function disconnect(int $code, string $reason, bool $byServer = false): void
     {
-        $this->connectionClose($code, 0, 0, $reason);
+        if(!$byServer)
+            $this->connectionClose($code, 0, 0, $reason);
         $this->connection->close();
 
         if ($this->heartbeatTimer === null) {
@@ -108,17 +127,17 @@ final class Connection
     private function onFrameReceived(AbstractFrame $frame): void
     {
         if ($frame instanceof MethodConnectionCloseFrame) {
-            $this->disconnect(Constants::STATUS_CONNECTION_FORCED, sprintf('Connection closed by server: (%d) %s', $frame->replyCode, $frame->replyText));
+            $this->client->disconnect(Constants::STATUS_CONNECTION_FORCED, sprintf('Connection closed by server: (%d) %s', $frame->replyCode, $frame->replyText), true);
 
             throw new ClientException(sprintf('Connection closed by server: %s', $frame->replyText), $frame->replyCode);
         }
 
         if ($frame instanceof ContentHeaderFrame) {
-            $this->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got header frame on connection channel (#0).');
+            $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got header frame on connection channel (#0).');
         }
 
         if ($frame instanceof ContentBodyFrame) {
-            $this->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got body frame on connection channel (#0).');
+            $this->client->disconnect(Constants::STATUS_UNEXPECTED_FRAME, 'Got body frame on connection channel (#0).');
         }
 
         if ($frame instanceof HeartbeatFrame) {


### PR DESCRIPTION
Hello,

I noticed a few issues that make it difficult to use Rabbit in rock-solid, long-running ReactPHP applications, especially related to handling errors, closed channels, and disconnects. I’ve prepared some fixes and improvements addressing these issues:

### 1. Unhandled exceptions in socket callback
Exceptions thrown in the socket incoming data callback crash the entire application, with no way for the user to catch them. I propose to catch these exceptions and emit "error" events via EventEmitter instead. This allows users to handle them gracefully, like this:
`$client->on('error', function($e) { /* ... */ });`
`$channel->on('error', function($e) { /* ... */ });`

### 2. Ignored connection/channel closing in some cases
If a connection or channel closes unexpectedly while no frame is awaited, Bunny handles it reasonably well. However, when a closing frame arrives in response to commands like exchangeDeclare, these events are ignored. For example, the channel does not update its own status and is not removed from the client's list of channels. I fixed this by adding the appropriate condition checks.

### 3. No detection of conenction loss
Bunny does not detect network-level connections losses, when no connection close frame is received, continuing to send data and wait indefinitely. I implemented handling for this situation by catching the socket 'close' event.

### 4. No way to handle disconnecion by user
Users currently have no way to detect when a connection has been lost. I propose emitting a 'close' event via EventEmitter so that applications can react accordingly.

### 5. Stuck on disconnect/close during server shutdown
When RabbitMQ shuts down, Bunny still attempts to send a connection close frame and waits indefinitely for a response, even though the server will no longer reply. In some cases, Bunny also tries to close a channel that has already been closed by the server. I resolved this by adding a $byServer flag in the disconnect() and close() methods, so that when the action is initiated by the server, the client does not attempt to perform it again and treats the connection or channel as already disconnected/closed.

These changes make Bunny more robust and predictable. I apologize if my code is not perfect. I am not very familiar with the internal workings of the AMQP protocol.