### PR TITLE
Throw exceptions for operations on closed or failed channel

### DIFF
--- a/src/Channel.php
+++ b/src/Channel.php
@@ -109,8 +109,20 @@ class Channel implements ChannelInterface, EventEmitterInterface
         $this->bodyBuffer = new Buffer();
     }
 
-    public function getClient(): Connection
+    protected function getClient(): Connection
     {
+        if ($this->state === ChannelState::Error) {
+            throw new ChannelException('Channel in error state.');
+        }
+
+        if ($this->state === ChannelState::Closing) {
+            throw new ChannelException('Channel is closing');
+        }
+
+        if ($this->state === ChannelState::Closed) {
+            throw new ChannelException('Channel is closed');
+        }
+
         return $this->connection;
     }
 

--- a/test/ChannelTest.php
+++ b/test/ChannelTest.php
@@ -265,4 +265,18 @@ class ChannelTest extends TestCase
 
         self::assertFalse($c->isConnected());
     }
+
+    public function testAttemptingToOperateOnANoLongerConnectedConnectionThrows(): void
+    {
+        self::expectException(ChannelException::class);
+        self::expectExceptionMessage('Channel is closed');
+
+        $c = $this->helper->createClient();
+
+        $ch = $c->connect()->channel();
+        self::assertTrue($c->isConnected());
+        $c->disconnect();
+        self::assertFalse($c->isConnected());
+        $ch->publish('hi', [], '', 'test_queue');
+    }
 }


### PR DESCRIPTION
Executing AMQP methods on a channel in `ChannelState::Error`, `ChannelState::Closing`, or `ChannelState::Closed` is pointless. In the case of a closed channel caused by a closed connection, it can even result in an infinite await while waiting for a response that will never arrive.

I propose throwing an exception immediately in these cases, without sending any frames to the server. In my opinion, the best place to implement these checks is the `getClient()` function, since it is used exclusively by the AMQP Channel method wrappers.