### PR TITLE
Emit client 'close' event

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -297,6 +297,8 @@ class Client implements ClientInterface, EventEmitterInterface
 
         $this->state = ClientState::Disconnecting;
 
+        $this->emit('close');
+
         $promises = [];
         foreach ($this->channels->all() as $channelId => $channel) {
             $promises[] = async(static function () use ($channel, $replyCode, $replyText): void {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -44,15 +44,21 @@ class ClientTest extends TestCase
 
     public function testConnect(): void
     {
+        $closeEmitted = null;
         $client = $this->helper->createClient();
+        $client->on('close', static function () use (&$closeEmitted): void {
+            $closeEmitted = true;
+        });
 
         self::assertFalse($client->isConnected());
 
         $client->connect();
 
         self::assertTrue($client->isConnected());
+        self::assertNull($closeEmitted);
         $client->disconnect();
         self::assertFalse($client->isConnected());
+        self::assertTrue($closeEmitted);
     }
 
     public function testConnectWithInvalidClientProperties(): void


### PR DESCRIPTION
Currently there is no way for the user to globally catch the disconnect, in order to trigger a reconnect for example. I suggest emitting a "close" event through Evenement on the `Client` object.