### PR TITLE
[0.6.x] Always clear heartbeat timer

### DIFF
--- a/spec/generate.php
+++ b/spec/generate.php
@@ -1058,6 +1058,10 @@ file_put_contents(__DIR__ . '/../src/Protocol/ProtocolWriterGenerated.php', $pro
 
 $connectionContent .= "    public function startHeartbeatTimer(): void\n";
 $connectionContent .= "    {\n";
+$connectionContent .= "        if (\$this->heartbeatTimer instanceof TimerInterface) {\n";
+$connectionContent .= "            Loop::cancelTimer(\$this->heartbeatTimer);\n";
+$connectionContent .= "        }\n";
+$connectionContent .= "\n";
 $connectionContent .= "        \$this->heartbeatTimer = Loop::addTimer(\$this->configuration->heartbeat, \$this->onHeartbeat(...));\n";
 $connectionContent .= "        \$this->connection->on('drain', \$this->onHeartbeat(...));\n";
 $connectionContent .= "    }\n";
@@ -1067,6 +1071,10 @@ $connectionContent .= "     * Callback when heartbeat timer timed out.\n";
 $connectionContent .= "     */\n";
 $connectionContent .= "    private function onHeartbeat(): void\n";
 $connectionContent .= "    {\n";
+$connectionContent .= "        if (\$this->heartbeatTimer instanceof TimerInterface) {\n";
+$connectionContent .= "            Loop::cancelTimer(\$this->heartbeatTimer);\n";
+$connectionContent .= "        }\n";
+$connectionContent .= "\n";
 $connectionContent .= "        \$now = microtime(true);\n";
 $connectionContent .= "        \$nextHeartbeat = (\$this->lastWrite ?: \$now) + \$this->configuration->heartbeat;\n";
 $connectionContent .= "\n";

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -2196,6 +2196,10 @@ final class Connection implements EventEmitterInterface
 
     public function startHeartbeatTimer(): void
     {
+        if ($this->heartbeatTimer instanceof TimerInterface) {
+            Loop::cancelTimer($this->heartbeatTimer);
+        }
+
         $this->heartbeatTimer = Loop::addTimer($this->configuration->heartbeat, $this->onHeartbeat(...));
         $this->connection->on('drain', $this->onHeartbeat(...));
     }
@@ -2205,6 +2209,10 @@ final class Connection implements EventEmitterInterface
      */
     private function onHeartbeat(): void
     {
+        if ($this->heartbeatTimer instanceof TimerInterface) {
+            Loop::cancelTimer($this->heartbeatTimer);
+        }
+
         $now = microtime(true);
         $nextHeartbeat = ($this->lastWrite ?: $now) + $this->configuration->heartbeat;
 


### PR DESCRIPTION
To ensure we don't end up with multiple timers keeping the event loop busy.

Fixes: #218