### PR TITLE
[0.6.x] Keep `var/` around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /vendor
 .phpunit.result.cache
 .phpunit.cache/
+var/*
+!var/.gitkeep


### PR DESCRIPTION
This directory is expected to exist to store things like the PHPCS cache. By adding a `.gitkeep` we have a add a reason for it being there, and can use it right away on a fresh checkout.