### PR TITLE
[0.6.x] Update examples to RabbitMQ v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ $bunny->connect();
 
 ### Publish a message
 
-Now that we have a connection with the server we need to create a channel and declare a queue to communicate over before we can publish a message, or subscribe to a queue for that matter.
+Now that we have a connection with the server we need to create a channel and declare a queue to communicate over before we can publish a message, or subscribe to a queue for that matter. On RabbitMQ 4 and newer, named queues must be durable; transient non-exclusive queues are deprecated and rejected by default.
 
 ```php
 $channel = $bunny->channel();
-$channel->queueDeclare('queue_name'); // Queue name
+$channel->queueDeclare('queue_name', durable: true);
 ```
 
 <details>
@@ -338,7 +338,7 @@ $channel->queueDeclare('queue_name'); // Queue name
   Loop::futureTick(async(static function (): void {
     $bunny->connect(); // Not required as the Client::channel() method handles this for us if we don't, but added for completeness sake
     $channel = $bunny->channel();
-    $channel->queueDeclare('queue_name'); // Queue name
+    $channel->queueDeclare('queue_name', durable: true);
     $channel->close(); // Not required as the Client::disconnect() method handles this for us if we don't, but added for completeness sake
     $bunny->disconnect();
   }));

--- a/benchmark/consumer.php
+++ b/benchmark/consumer.php
@@ -14,7 +14,7 @@ $client = new Client();
 Loop::futureTick(async(static function () use ($client): void {
     $channel = $client->channel();
 
-    $channel->queueDeclare('bench_queue');
+    $channel->queueDeclare('bench_queue', durable: true);
     $channel->exchangeDeclare('bench_exchange');
     $channel->queueBind('bench_exchange', 'bench_queue');
 

--- a/benchmark/producer.php
+++ b/benchmark/producer.php
@@ -12,7 +12,7 @@ $client = new Client();
 Loop::futureTick(async(static function () use ($argv, $client): void {
     $channel = $client->channel();
 
-    $channel->queueDeclare('bench_queue');
+    $channel->queueDeclare('bench_queue', durable: true);
     $channel->exchangeDeclare('bench_exchange');
     $channel->queueBind('bench_exchange', 'bench_queue');
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ networks:
   main:
 services:
   rabbit_node_1:
-    image: 'rabbitmq:3-management'
+    image: 'rabbitmq:4-management'
     entrypoint: /opt/bunny/docker/rabbitmq/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
     command: rabbitmq-server
     environment:

--- a/examples/worker.php
+++ b/examples/worker.php
@@ -42,7 +42,7 @@ $clientConfig = [
 $client = new Client($clientConfig);
 $channel = $client->channel();
 $channel->qos(0, 13);
-$channel->queueDeclare('hello', false, false, false, false);
+$channel->queueDeclare('hello', durable: true);
 $channelRef = $channel;
 echo ' [*] Waiting for messages. To exit press CTRL+C', "\n";
 $response = $channel->consume(

--- a/tutorial/1-hello-world/receive.php
+++ b/tutorial/1-hello-world/receive.php
@@ -14,7 +14,7 @@ $client = new Client();
 Loop::futureTick(async(static function () use ($client): void {
     $channel = $client->channel();
 
-    $channel->queueDeclare('hello', false, false, false, false);
+    $channel->queueDeclare('hello', durable: true);
 
     echo ' [*] Waiting for messages. To exit press CTRL+C', PHP_EOL;
 

--- a/tutorial/1-hello-world/send.php
+++ b/tutorial/1-hello-world/send.php
@@ -11,7 +11,7 @@ require dirname(__DIR__, 2) . '/vendor/autoload.php';
 $client = new Client();
 Loop::futureTick(async(static function () use ($client): void {
     $channel = $client->channel();
-    $channel->queueDeclare('hello', false, false, false, false);
+    $channel->queueDeclare('hello', durable: true);
 
     $channel->publish('Hello World!', [], '', 'hello');
     echo ' [x] Sent "Hello World!"' . PHP_EOL;

--- a/tutorial/6-rpc/rpc_server.php
+++ b/tutorial/6-rpc/rpc_server.php
@@ -27,7 +27,7 @@ $client = new Client();
 Loop::futureTick(async(static function () use ($client): void {
     $channel = $client->channel();
 
-    $channel->queueDeclare('rpc_queue');
+    $channel->queueDeclare('rpc_queue', durable: true);
 
     echo ' [x] Awaiting RPC requests' . PHP_EOL;
 


### PR DESCRIPTION
While there is no immidiate support to drop RabbitMQ v3 support. [V4 deprecated `transient_nonexcl_queues`](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements#removal-of-transient-non-exclusive-queues) and is throwing errors when you try to declare those through Bunny.